### PR TITLE
Make MoreUnit easier accessible for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing Guidelines
+You have to follow two rules only when contributing:
+
+* Produce readable code
+* **No Tests -> No Merge!**
+
+# Development Environment Setup
+If you plan to contribute a feature or bugfix to this project or just the want to have a closer look at the sources,
+the following steps describe the setup of the development environment.
+ 
+1. Start an Eclipse IDE v4.4 (Luna) or later that has the [Plug-in Development Environment (PDE)](https://www.eclipse.org/pde/) installed.
+ If you want to use a fresh Eclipse installation, you can download the _Eclipse IDE for Eclipse Committers_ package from the [Eclipse Downloads](https://www.eclipse.org/downloads/packages/) page.
+It contains everything you need.
+ 
+2. Clone the git repository from https://github.com/MoreUnit/MoreUnit-Eclipse.git
+ 
+3. The necessary projects are located at the root of the repository. 
+Import all of them into your workspace.
+
+4. The `org.moreunit.build` project contains suitable [Target Platform Definitions](http://help.eclipse.org/juno/index.jsp?topic=%2Forg.eclipse.pde.doc.user%2Fconcepts%2Ftarget.htm).
+Open one of them and select the _Set as Target Platform_ link.
+
+
+Now you are ready to hack the sources.
+If you whish to verify the setup, you can run the test suite. The launch configuration to run all tests is called _All Tests_
+
+MoreUnit-clipse uses Maven/Tycho to build, the master pom file can be found in the `org.moreunit.build` project.
+
+
+# Project License:  Eclipse Public License
+By contributing code you automatically agree with the following points regarding licensing:
+
+* You will only Submit Contributions where You have authored 100% of the content.
+* You will only Submit Contributions to which You have the necessary rights. This means that if You are employed You have received the necessary permissions from Your employer to make the Contributions.
+* Whatever content You Contribute will be provided under the Project License. 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,9 +22,9 @@ Open one of them and select the _Set as Target Platform_ link.
 
 
 Now you are ready to hack the sources.
-If you whish to verify the setup, you can run the test suite. The launch configuration to run all tests is called _All Tests_
+If you wish to verify the setup, you can run the Maven/Tycho build with the `mvn clean install` launch configuration.
 
-MoreUnit-clipse uses Maven/Tycho to build, the master pom file can be found in the `org.moreunit.build` project.
+MoreUnit-Eclipse uses Maven/Tycho to build, the master pom file can be found in the `org.moreunit.build` project.
 
 
 # Project License:  Eclipse Public License

--- a/org.moreunit.build/eclipse-4.3.target
+++ b/org.moreunit.build/eclipse-4.3.target
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?><target name="eclipse-4.6.milestones" sequenceNumber="7">
+<locations>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.swtbot.feature.group" version="2.3.0.201506081302"/>
+<unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.3.0.201506081302"/>
+<repository location="http://download.eclipse.org/technology/swtbot/releases/latest/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.testng.eclipse.feature.group" version="6.9.11.201604020423"/>
+<repository location="http://beust.com/eclipse"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.sdk.ide" version="4.3.2.M20140221-1700"/>
+<repository location="http://download.eclipse.org/eclipse/updates/4.3"/>
+</location>
+</locations>
+</target>

--- a/org.moreunit.build/eclipse-4.3.target
+++ b/org.moreunit.build/eclipse-4.3.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="eclipse-4.6.milestones" sequenceNumber="7">
+<?pde version="3.8"?><target name="eclipse-4.3" sequenceNumber="7">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtbot.feature.group" version="2.3.0.201506081302"/>

--- a/org.moreunit.build/eclipse-4.4.target
+++ b/org.moreunit.build/eclipse-4.4.target
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?><target name="eclipse-4.6.milestones" sequenceNumber="6">
+<locations>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.swtbot.feature.group" version="2.3.0.201506081302"/>
+<unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.3.0.201506081302"/>
+<repository location="http://download.eclipse.org/technology/swtbot/releases/latest/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.testng.eclipse.feature.group" version="6.9.11.201604020423"/>
+<repository location="http://beust.com/eclipse"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.sdk.ide" version="4.4.2.M20150204-1700"/>
+<repository location="http://download.eclipse.org/eclipse/updates/4.4"/>
+</location>
+</locations>
+</target>

--- a/org.moreunit.build/eclipse-4.4.target
+++ b/org.moreunit.build/eclipse-4.4.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="eclipse-4.6.milestones" sequenceNumber="6">
+<?pde version="3.8"?><target name="eclipse-4.4" sequenceNumber="6">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtbot.feature.group" version="2.3.0.201506081302"/>

--- a/org.moreunit.build/eclipse-4.5.target
+++ b/org.moreunit.build/eclipse-4.5.target
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?><target name="eclipse-4.6.milestones" sequenceNumber="5">
+<locations>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.swtbot.feature.group" version="2.3.0.201506081302"/>
+<unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.3.0.201506081302"/>
+<repository location="http://download.eclipse.org/technology/swtbot/releases/latest/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.testng.eclipse.feature.group" version="6.9.11.201604020423"/>
+<repository location="http://beust.com/eclipse"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.sdk.ide" version="4.5.2.M20160212-1500"/>
+<repository location="http://download.eclipse.org/eclipse/updates/4.5"/>
+</location>
+</locations>
+</target>

--- a/org.moreunit.build/eclipse-4.5.target
+++ b/org.moreunit.build/eclipse-4.5.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="eclipse-4.6.milestones" sequenceNumber="5">
+<?pde version="3.8"?><target name="eclipse-4.5" sequenceNumber="5">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtbot.feature.group" version="2.3.0.201506081302"/>

--- a/org.moreunit.build/eclipse-4.6.i-builds.target
+++ b/org.moreunit.build/eclipse-4.6.i-builds.target
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?><target name="eclipse-4.6.milestones" sequenceNumber="3">
+<locations>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.sdk.ide" version="4.6.0.I20160405-0800"/>
+<repository location="http://download.eclipse.org/eclipse/updates/4.6-I-builds"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.swtbot.feature.group" version="2.3.0.201506081302"/>
+<unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.3.0.201506081302"/>
+<repository location="http://download.eclipse.org/technology/swtbot/releases/latest/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.testng.eclipse.feature.group" version="6.9.11.201604020423"/>
+<repository location="http://beust.com/eclipse"/>
+</location>
+</locations>
+</target>

--- a/org.moreunit.build/mvn clean install.launch
+++ b/org.moreunit.build/mvn clean install.launch
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
+<booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
+<stringAttribute key="M2_GOALS" value="clean install"/>
+<booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
+<booleanAttribute key="M2_OFFLINE" value="false"/>
+<stringAttribute key="M2_PROFILES" value=""/>
+<listAttribute key="M2_PROPERTIES"/>
+<stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
+<booleanAttribute key="M2_SKIP_TESTS" value="false"/>
+<intAttribute key="M2_THREADS" value="1"/>
+<booleanAttribute key="M2_UPDATE_SNAPSHOTS" value="false"/>
+<stringAttribute key="M2_USER_SETTINGS" value=""/>
+<booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
+<stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${project_loc:org.moreunit.build}"/>
+</launchConfiguration>

--- a/org.moreunit.build/pom.xml
+++ b/org.moreunit.build/pom.xml
@@ -31,24 +31,6 @@
     <tests.use.ui>false</tests.use.ui>
   </properties>
 
-  <repositories>
-    <repository>
-      <id>kepler</id>
-      <layout>p2</layout>
-      <url>http://download.eclipse.org/releases/kepler</url>
-    </repository>
-    <repository>
-      <id>testng</id>
-      <layout>p2</layout>
-      <url>http://beust.com/eclipse</url>
-    </repository>
-    <repository>
-     <id>swtbot</id>
-     <layout>p2</layout>
-     <url>http://download.eclipse.org/technology/swtbot/releases/latest/</url>
-   </repository>
-  </repositories>
-
   <build>
     <extensions>
       <extension>
@@ -148,6 +130,15 @@
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>target-platform-configuration</artifactId>
         <configuration>
+          <target>
+            <artifact>
+              <groupId>org.moreunit</groupId>
+              <artifactId>moreunit</artifactId>
+              <version>${project.version}</version>
+              <classifier>eclipse-4.3</classifier>
+            </artifact>
+          </target>
+          <includePackedArtifacts>true</includePackedArtifacts>
           <resolver>p2</resolver>
           <environments>
             <environment>
@@ -189,7 +180,7 @@
       <plugin>
         <artifactId>maven-deploy-plugin</artifactId>
         <executions>
-          <!-- Deactivates standard Maven "deploy" goal at "deploy" phase, that makes no sens for an Eclipse plug-in. -->
+          <!-- Deactivates standard Maven "deploy" goal at "deploy" phase, that makes no sense for an Eclipse plug-in. -->
           <!-- Our deployment is handled via the org.moreunit.updatesite module -->
           <execution>
             <id>default-deploy</id>

--- a/org.moreunit.plugin/src/org/moreunit/annotation/MoreUnitAnnotationModel.java
+++ b/org.moreunit.plugin/src/org/moreunit/annotation/MoreUnitAnnotationModel.java
@@ -36,8 +36,8 @@ import org.moreunit.elements.ClassTypeFacade;
 import org.moreunit.elements.EditorPartFacade;
 import org.moreunit.elements.TypeFacade;
 import org.moreunit.log.LogHandler;
-import org.moreunit.preferences.TestAnnotationMode;
 import org.moreunit.preferences.Preferences;
+import org.moreunit.preferences.TestAnnotationMode;
 
 /**
  * @author vera 01.02.2009 14:27:06
@@ -49,7 +49,7 @@ public class MoreUnitAnnotationModel implements IAnnotationModel
 
     private static final String MODEL_KEY = "org.moreunit.model_key";
 
-    private final List<Annotation> annotations = Collections.synchronizedList(new ArrayList<Annotation>());
+    private final List<MoreUnitAnnotation> annotations = Collections.synchronizedList(new ArrayList<MoreUnitAnnotation>());
     private final List<IAnnotationModelListener> annotationModelListeners = new ArrayList<IAnnotationModelListener>(2);
     private final IDocument document;
     private final ITextEditor textEditor;
@@ -152,10 +152,10 @@ public class MoreUnitAnnotationModel implements IAnnotationModel
     {
         synchronized (annotations)
         {
-            for (Annotation annotation : annotations)
+            for (MoreUnitAnnotation annotation : annotations)
             {
                 annotation.markDeleted(true);
-                event.annotationRemoved(annotation, ((MoreUnitAnnotation) annotation).getPosition());
+                event.annotationRemoved(annotation, annotation.getPosition());
             }
 
             annotations.clear();
@@ -304,11 +304,11 @@ public class MoreUnitAnnotationModel implements IAnnotationModel
             throw new RuntimeException("Can not connect");
         }
 
-        for (Annotation annotation : annotations)
+        for (MoreUnitAnnotation annotation : annotations)
         {
             try
             {
-                document.addPosition(((MoreUnitAnnotation) annotation).getPosition());
+                document.addPosition(annotation.getPosition());
             }
             catch (BadLocationException exc)
             {
@@ -324,15 +324,16 @@ public class MoreUnitAnnotationModel implements IAnnotationModel
             throw new RuntimeException("Can not connect");
         }
 
-        for (Annotation annotation : annotations)
+        for (MoreUnitAnnotation annotation : annotations)
         {
-            document.removePosition(((MoreUnitAnnotation) annotation).getPosition());
+            document.removePosition(annotation.getPosition());
         }
     }
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public Iterator<Annotation> getAnnotationIterator()
     {
-        return annotations.iterator();
+        return new ArrayList(annotations).iterator();
     }
 
     public Position getPosition(Annotation annotation)

--- a/org.moreunit.plugin/src/org/moreunit/annotation/MoreUnitAnnotationModel.java
+++ b/org.moreunit.plugin/src/org/moreunit/annotation/MoreUnitAnnotationModel.java
@@ -49,7 +49,7 @@ public class MoreUnitAnnotationModel implements IAnnotationModel
 
     private static final String MODEL_KEY = "org.moreunit.model_key";
 
-    private final List<MoreUnitAnnotation> annotations = Collections.synchronizedList(new ArrayList<MoreUnitAnnotation>());
+    private final List<Annotation> annotations = Collections.synchronizedList(new ArrayList<Annotation>());
     private final List<IAnnotationModelListener> annotationModelListeners = new ArrayList<IAnnotationModelListener>(2);
     private final IDocument document;
     private final ITextEditor textEditor;
@@ -152,10 +152,10 @@ public class MoreUnitAnnotationModel implements IAnnotationModel
     {
         synchronized (annotations)
         {
-            for (MoreUnitAnnotation annotation : annotations)
+            for (Annotation annotation : annotations)
             {
                 annotation.markDeleted(true);
-                event.annotationRemoved(annotation, annotation.getPosition());
+                event.annotationRemoved(annotation, ((MoreUnitAnnotation) annotation).getPosition());
             }
 
             annotations.clear();
@@ -304,11 +304,11 @@ public class MoreUnitAnnotationModel implements IAnnotationModel
             throw new RuntimeException("Can not connect");
         }
 
-        for (MoreUnitAnnotation annotation : annotations)
+        for (Annotation annotation : annotations)
         {
             try
             {
-                document.addPosition(annotation.getPosition());
+                document.addPosition(((MoreUnitAnnotation) annotation).getPosition());
             }
             catch (BadLocationException exc)
             {
@@ -324,13 +324,13 @@ public class MoreUnitAnnotationModel implements IAnnotationModel
             throw new RuntimeException("Can not connect");
         }
 
-        for (MoreUnitAnnotation annotation : annotations)
+        for (Annotation annotation : annotations)
         {
-            document.removePosition(annotation.getPosition());
+            document.removePosition(((MoreUnitAnnotation) annotation).getPosition());
         }
     }
 
-    public Iterator<MoreUnitAnnotation> getAnnotationIterator()
+    public Iterator<Annotation> getAnnotationIterator()
     {
         return annotations.iterator();
     }


### PR DESCRIPTION
The change adds target platforms for Eclipse versions 4.3 - 4.6.
The master pom uses the eclipse-4.3 (Kepler) target platform so that
the behavior of the tycho build remains unchanged.
Changing MoreUnitAnnotationModel became necessary because of compile
errors with the 4.6 target platform.