### PR TITLE
Fix #25: Use a stable repository to consume SWTBot

### DIFF
--- a/org.moreunit.build/eclipse-4.3.target
+++ b/org.moreunit.build/eclipse-4.3.target
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="eclipse-4.3" sequenceNumber="7">
+<?pde version="3.8"?><target name="eclipse-4.3" sequenceNumber="8">
 <locations>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.swtbot.feature.group" version="2.3.0.201506081302"/>
-<unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.3.0.201506081302"/>
-<repository location="http://download.eclipse.org/technology/swtbot/releases/latest/"/>
-</location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.testng.eclipse.feature.group" version="6.9.11.201604020423"/>
 <repository location="http://beust.com/eclipse"/>
@@ -13,6 +8,11 @@
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.sdk.ide" version="4.3.2.M20140221-1700"/>
 <repository location="http://download.eclipse.org/eclipse/updates/4.3"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.4.0.201604200752"/>
+<unit id="org.eclipse.swtbot.feature.group" version="2.4.0.201604200752"/>
+<repository location="http://download.eclipse.org/technology/swtbot/releases/2.4.0/"/>
 </location>
 </locations>
 </target>

--- a/org.moreunit.build/eclipse-4.4.target
+++ b/org.moreunit.build/eclipse-4.4.target
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="eclipse-4.4" sequenceNumber="6">
+<?pde version="3.8"?><target name="eclipse-4.4" sequenceNumber="7">
 <locations>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.swtbot.feature.group" version="2.3.0.201506081302"/>
-<unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.3.0.201506081302"/>
-<repository location="http://download.eclipse.org/technology/swtbot/releases/latest/"/>
-</location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.testng.eclipse.feature.group" version="6.9.11.201604020423"/>
 <repository location="http://beust.com/eclipse"/>
@@ -13,6 +8,11 @@
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.sdk.ide" version="4.4.2.M20150204-1700"/>
 <repository location="http://download.eclipse.org/eclipse/updates/4.4"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.4.0.201604200752"/>
+<unit id="org.eclipse.swtbot.feature.group" version="2.4.0.201604200752"/>
+<repository location="http://download.eclipse.org/technology/swtbot/releases/2.4.0/"/>
 </location>
 </locations>
 </target>

--- a/org.moreunit.build/eclipse-4.5.target
+++ b/org.moreunit.build/eclipse-4.5.target
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="eclipse-4.5" sequenceNumber="5">
+<?pde version="3.8"?><target name="eclipse-4.5" sequenceNumber="6">
 <locations>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.swtbot.feature.group" version="2.3.0.201506081302"/>
-<unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.3.0.201506081302"/>
-<repository location="http://download.eclipse.org/technology/swtbot/releases/latest/"/>
-</location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.testng.eclipse.feature.group" version="6.9.11.201604020423"/>
 <repository location="http://beust.com/eclipse"/>
@@ -13,6 +8,11 @@
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.sdk.ide" version="4.5.2.M20160212-1500"/>
 <repository location="http://download.eclipse.org/eclipse/updates/4.5"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.4.0.201604200752"/>
+<unit id="org.eclipse.swtbot.feature.group" version="2.4.0.201604200752"/>
+<repository location="http://download.eclipse.org/technology/swtbot/releases/2.4.0/"/>
 </location>
 </locations>
 </target>

--- a/org.moreunit.build/eclipse-4.6.i-builds.target
+++ b/org.moreunit.build/eclipse-4.6.i-builds.target
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="eclipse-4.6.milestones" sequenceNumber="3">
+<?pde version="3.8"?><target name="eclipse-4.6.milestones" sequenceNumber="5">
 <locations>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.sdk.ide" version="4.6.0.I20160405-0800"/>
-<repository location="http://download.eclipse.org/eclipse/updates/4.6-I-builds"/>
-</location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.swtbot.feature.group" version="2.3.0.201506081302"/>
-<unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.3.0.201506081302"/>
-<repository location="http://download.eclipse.org/technology/swtbot/releases/latest/"/>
-</location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.testng.eclipse.feature.group" version="6.9.11.201604020423"/>
 <repository location="http://beust.com/eclipse"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.4.0.201604200752"/>
+<unit id="org.eclipse.swtbot.feature.group" version="2.4.0.201604200752"/>
+<repository location="http://download.eclipse.org/technology/swtbot/releases/2.4.0/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.sdk.ide" version="4.6.0.I20160428-0800"/>
+<repository location="http://download.eclipse.org/eclipse/updates/4.6-I-builds"/>
 </location>
 </locations>
 </target>


### PR DESCRIPTION
This commit changes the SWTBot repository to v2.4 for all target platforms 

All test pass except this one (fails on all Eclipse versions):
However, I don't think this is related to a particular SWTBot version. Can anyone figure why this test fails?
```
org.moreunit.swtbot.test
org.moreunit.refactoring.RenameMethodTest
should_rename_corresponding_test_methods_when_method_gets_renamed(org.moreunit.refactoring.RenameMethodTest)
org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException: Could not find widget matching: (of type 'Text' and with label (with mnemonic 'New name:'))

	at org.eclipse.swtbot.swt.finder.SWTBotFactory.waitUntilWidgetAppears(SWTBotFactory.java:472)

	at org.eclipse.swtbot.swt.finder.SWTBotFactory.widget(SWTBotFactory.java:419)

	at org.eclipse.swtbot.swt.finder.SWTBot.textWithLabel(SWTBot.java:1478)

	at org.eclipse.swtbot.swt.finder.SWTBot.textWithLabel(SWTBot.java:1466)

	at org.moreunit.refactoring.RenameMethodTest.renameMethodAndWaitUntilFinished(RenameMethodTest.java:56)

	at org.moreunit.refactoring.RenameMethodTest.should_rename_corresponding_test_methods_when_method_gets_renamed(RenameMethodTest.java:37)

	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)

	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)

	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)

	at java.lang.reflect.Method.invoke(Unknown Source)

	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)

	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)

	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)

	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)

	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)

	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)

	at org.moreunit.test.context.TestContextRule$StatementInContext.evaluate(TestContextRule.java:244)

	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)

	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)

	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)

	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)

	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)

	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)

	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)

	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)

	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)

	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)

	at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:86)

	at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:38)

	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:459)

	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:678)

	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:382)

	at org.eclipse.pde.internal.junit.runtime.RemotePluginTestRunner.main(RemotePluginTestRunner.java:66)

	at org.eclipse.pde.internal.junit.runtime.PlatformUITestHarness.lambda$0(PlatformUITestHarness.java:43)

	at org.eclipse.pde.internal.junit.runtime.PlatformUITestHarness$$Lambda$58/1182904162.run(Unknown Source)

	at java.lang.Thread.run(Unknown Source)

Caused by: org.eclipse.swtbot.swt.finder.widgets.TimeoutException: Timeout after: 5000 ms.: Could not find widget matching: (of type 'Text' and with label (with mnemonic 'New name:'))

	at org.eclipse.swtbot.swt.finder.SWTBotFactory.waitUntil(SWTBotFactory.java:522)

	at org.eclipse.swtbot.swt.finder.SWTBotFactory.waitUntil(SWTBotFactory.java:496)

	at org.eclipse.swtbot.swt.finder.SWTBotFactory.waitUntil(SWTBotFactory.java:484)

	at org.eclipse.swtbot.swt.finder.SWTBotFactory.waitUntilWidgetAppears(SWTBotFactory.java:466)

	... 35 more



org.moreunit.refactoring.MoveMethodTest
should_move_test_method_when_static_method_gets_moved(org.moreunit.refactoring.MoveMethodTest)
org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException: Could not find shell matching: with text 'Open Resource'

	at org.eclipse.swtbot.swt.finder.SWTBotFactory.waitUntilWidgetAppears(SWTBotFactory.java:472)

	at org.eclipse.swtbot.swt.finder.SWTBotFactory.shells(SWTBotFactory.java:116)

	at org.eclipse.swtbot.swt.finder.SWTBotFactory.shell(SWTBotFactory.java:106)

	at org.eclipse.swtbot.swt.finder.SWTBotFactory.shell(SWTBotFactory.java:97)

	at org.moreunit.JavaProjectSWTBotTestHelper.openResource(JavaProjectSWTBotTestHelper.java:133)

	at org.moreunit.refactoring.MoveMethodTest.should_move_test_method_when_static_method_gets_moved(MoveMethodTest.java:30)

	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)

	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)

	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)

	at java.lang.reflect.Method.invoke(Unknown Source)

	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)

	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)

	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)

	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)

	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)

	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)

	at org.moreunit.test.context.TestContextRule$StatementInContext.evaluate(TestContextRule.java:244)

	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)

	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)

	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)

	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)

	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)

	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)

	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)

	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)

	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)

	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)

	at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:86)

	at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:38)

	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:459)

	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:678)

	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:382)

	at org.eclipse.pde.internal.junit.runtime.RemotePluginTestRunner.main(RemotePluginTestRunner.java:66)

	at org.eclipse.pde.internal.junit.runtime.PlatformUITestHarness.lambda$0(PlatformUITestHarness.java:43)

	at org.eclipse.pde.internal.junit.runtime.PlatformUITestHarness$$Lambda$58/1182904162.run(Unknown Source)

	at java.lang.Thread.run(Unknown Source)

Caused by: org.eclipse.swtbot.swt.finder.widgets.TimeoutException: Timeout after: 5000 ms.: Could not find shell matching: with text 'Open Resource'

	at org.eclipse.swtbot.swt.finder.SWTBotFactory.waitUntil(SWTBotFactory.java:522)

	at org.eclipse.swtbot.swt.finder.SWTBotFactory.waitUntil(SWTBotFactory.java:496)

	at org.eclipse.swtbot.swt.finder.SWTBotFactory.waitUntil(SWTBotFactory.java:484)

	at org.eclipse.swtbot.swt.finder.SWTBotFactory.waitUntilWidgetAppears(SWTBotFactory.java:466)

	... 35 more

```