### PR TITLE
#40 - update documentation to point to new github update site instead of

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -805,14 +805,13 @@
 			<header>Download</header>
 			<section>
 				<h1>Update site</h1>
-				<p>Use the following update site:</p><pre>http://moreunit.sourceforge.net/update-site/</pre>
+				<p>Use the following update site:</p><pre>https://github.com/MoreUnit/eclipse-update-site</pre>
 				<p>The old update-site <em>http://moreunit.sourceforge.net/org.moreunit.updatesite/</em> has been freezed with version 1.3.3. If you are
 				still using this version and want to upgrade, please uninstall older versions of MoreUnit first: the feature id has changed and you will get
 				error messages if older versions are still installed when switching to version 2.x.x.</p>
-
-				<h1>From Sourceforge</h1>
-				<p>Download the plugin from: <a href="http://sourceforge.net/projects/moreunit">http://sourceforge.net/projects/moreunit</a>. You can also use
-				this <a href="http://sourceforge.net/projects/moreunit/files/latest/download" target="blank">direct link</a> to the latest relase.</p>
+				
+				<h1>Zipped update site</h1>
+				<p>The zipped update site is available from </p><pre>https://github.com/MoreUnit/MoreUnit-Eclipse/releases</pre>
 				
 				<h1>Like this plugin?</h1>
 				<p><a href="http://marketplace.eclipse.org/content/moreunit"><img src="img/star.png" border="0"/></a>
@@ -823,7 +822,6 @@
 		</div><!-- end of #site-content -->
 		
 		<footer id="site-footer">
-			<a href="http://sourceforge.net"><img src="http://sflogo.sourceforge.net/sflogo.php?group_id=156007&amp;type=4" alt="SourceForge.net Logo" width="125" height="37"></a>
 			<a href="http://www.ej-technologies.com/products/jprofiler/overview.html"><img src="img/jprofiler.png" width="99" height="26"/></a>
 			<a href="https://twitter.com/moreunit" class="twitter-follow-button" data-show-count="false" data-dnt="true">Follow @moreunit</a>
 <script src="//platform.twitter.com/widgets.js" id="twitter-wjs"></script>


### PR DESCRIPTION
sourceforge

Signed-off-by: Aurélien Pupier <apupier@redhat.com>