### PR TITLE
Provide Target Platform for Eclipse Photon 4.8 (#61)

### DIFF
--- a/org.moreunit.build/eclipse-4.8.target
+++ b/org.moreunit.build/eclipse-4.8.target
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?><target name="eclipse-4.8" sequenceNumber="9">
+<locations>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.testng.eclipse.feature.group" version="6.14.0.201802161500"/>
+<repository location="http://beust.com/eclipse"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.7.0.201806111355"/>
+<unit id="org.eclipse.swtbot.feature.group" version="2.7.0.201806111355"/>
+<repository location="http://download.eclipse.org/technology/swtbot/releases/2.7.0/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.sdk.ide" version="4.8.0.I20180611-0500"/>
+<repository location="http://download.eclipse.org/eclipse/updates/4.8"/>
+</location>
+</locations>
+</target>

--- a/org.moreunit.build/pom.xml
+++ b/org.moreunit.build/pom.xml
@@ -23,7 +23,7 @@
   </modules>
 
   <properties>
-    <tycho-version>0.19.0</tycho-version>
+    <tycho-version>1.2.0</tycho-version>
     
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -36,7 +36,7 @@
       <extension>
         <groupId>org.codehaus.mojo</groupId>
 		<artifactId>exec-maven-plugin</artifactId>
-        <version>1.2.1</version>
+        <version>1.6.0</version>
       </extension>
     </extensions>
 
@@ -65,12 +65,15 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.12.1</version>
+          <version>2.22.0</version>
         </plugin>
         <plugin>
           <groupId>org.eclipse.tycho</groupId>
           <artifactId>tycho-surefire-plugin</artifactId>
           <version>${tycho-version}</version>
+          <configuration>
+          	<providerHint>junit4</providerHint>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.eclipse.tycho</groupId>
@@ -85,17 +88,17 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>2.4</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>2.5</version>
+          <version>2.8.2</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <version>1.2.1</version>
+          <version>1.6.0</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/org.moreunit.swtbot.test/src/org/moreunit/settings/PreferencesTest.java
+++ b/org.moreunit.swtbot.test/src/org/moreunit/settings/PreferencesTest.java
@@ -47,6 +47,8 @@ public class PreferencesTest extends JavaProjectSWTBotTestHelper
 
     private void saveAndClosePrefs()
     {
+        // Needs to be changed to "Apply and close" or JFaceResources.getString("PreferencesDialog.okButtonLabel")
+        // or find another way in newer version (4.7?, 4.8)
         bot.button("OK").click();
     }
 

--- a/org.moreunit.swtbot.test/src/org/moreunit/settings/PropertiesTest.java
+++ b/org.moreunit.swtbot.test/src/org/moreunit/settings/PropertiesTest.java
@@ -68,6 +68,8 @@ public class PropertiesTest extends JavaProjectSWTBotTestHelper
 
     private void saveAndCloseProps()
     {
+        // Needs to be changed to "Apply and close" or JFaceResources.getString("PreferencesDialog.okButtonLabel")
+        // or find another way in newer version (4.7?, 4.8)
         bot.button("OK").click();
     }
 


### PR DESCRIPTION
- requires upgrade of Tycho Maven plugins to be able to parse correctly
metadata of Manifest Headers of newly built Photon plugins
- as Tycho upgraded and project containing test of several kind,
requires to specify as hint the "junit4" type of Tycho tests.
- detected some modifications that will required in SWTBot test if
playing tests against this 4.8 TP
- still failing test with JMockit with TP4.8 (but suspect it is the case
since several versions)

Signed-off-by: Aurélien Pupier <apupier@redhat.com>