### PR TITLE
61 target platform for eclipse4.8 with travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: java
+env: 
+  global:
+  - DISPLAY=:99
+before_script:
+  - cd org.moreunit.build
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
+script: mvn verify -fae
+jdk: 
+  - oraclejdk8
+cache:
+  directories:
+    - $HOME/.m2

--- a/org.moreunit.build/eclipse-4.8.target
+++ b/org.moreunit.build/eclipse-4.8.target
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?><target name="eclipse-4.8" sequenceNumber="9">
+<locations>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.testng.eclipse.feature.group" version="6.14.0.201802161500"/>
+<repository location="http://beust.com/eclipse"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.7.0.201806111355"/>
+<unit id="org.eclipse.swtbot.feature.group" version="2.7.0.201806111355"/>
+<repository location="http://download.eclipse.org/technology/swtbot/releases/2.7.0/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.sdk.ide" version="4.8.0.I20180611-0500"/>
+<repository location="http://download.eclipse.org/eclipse/updates/4.8"/>
+</location>
+</locations>
+</target>

--- a/org.moreunit.build/pom.xml
+++ b/org.moreunit.build/pom.xml
@@ -23,7 +23,7 @@
   </modules>
 
   <properties>
-    <tycho-version>0.19.0</tycho-version>
+    <tycho-version>1.2.0</tycho-version>
     
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -36,7 +36,7 @@
       <extension>
         <groupId>org.codehaus.mojo</groupId>
 		<artifactId>exec-maven-plugin</artifactId>
-        <version>1.2.1</version>
+        <version>1.6.0</version>
       </extension>
     </extensions>
 
@@ -65,12 +65,15 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.12.1</version>
+          <version>2.22.0</version>
         </plugin>
         <plugin>
           <groupId>org.eclipse.tycho</groupId>
           <artifactId>tycho-surefire-plugin</artifactId>
           <version>${tycho-version}</version>
+          <configuration>
+          	<providerHint>junit4</providerHint>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.eclipse.tycho</groupId>
@@ -85,17 +88,17 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
-          <version>2.4</version>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
-          <version>2.5</version>
+          <version>2.8.2</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <version>1.2.1</version>
+          <version>1.6.0</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -135,7 +138,7 @@
               <groupId>org.moreunit</groupId>
               <artifactId>moreunit</artifactId>
               <version>${project.version}</version>
-              <classifier>eclipse-4.3</classifier>
+              <classifier>eclipse-4.8</classifier>
             </artifact>
           </target>
           <includePackedArtifacts>true</includePackedArtifacts>

--- a/org.moreunit.build/pom.xml
+++ b/org.moreunit.build/pom.xml
@@ -175,6 +175,7 @@
         <configuration>
           <useUIHarness>${tests.use.ui}</useUIHarness>
           <useUIThread>${tests.use.ui}</useUIThread>
+          <appArgLine>-consoleLog</appArgLine>
         </configuration>
       </plugin>
       <plugin>

--- a/org.moreunit.mock.it/test/org/moreunit/mock/it/JMockit_all_dependencies.expected.java.txt
+++ b/org.moreunit.mock.it/test/org/moreunit/mock/it/JMockit_all_dependencies.expected.java.txt
@@ -1,9 +1,9 @@
 package te.st;
 
+import org.junit.runner.RunWith;
 import mockit.Injectable;
 import mockit.Tested;
 import mockit.integration.junit4.JMockit;
-import org.junit.runner.RunWith;
 import te.st.SomeConcept.Comparator;
 import te.st.SomeConcept.List;
 import te.st.SomeConcept.Thing;

--- a/org.moreunit.plugin/src/org/moreunit/refactoring/RenamePackageParticipant.java
+++ b/org.moreunit.plugin/src/org/moreunit/refactoring/RenamePackageParticipant.java
@@ -82,21 +82,25 @@ public class RenamePackageParticipant extends RenameParticipant
 
         List<Change> changes = new ArrayList<Change>();
 
+
         for (IPackageFragmentRoot packageRoot : correspondingPackageFragmentRoots)
         {
-            IPackageFragment packageToRename = packageRoot.getPackageFragment(PluginTools.getTestPackageName(cutPackageName, prefs));
-            if(packageToRename != null && packageToRename.exists())
+            if(packageRoot.getResource() != null)
             {
-                RefactoringContribution refactoringContribution = RefactoringCore.getRefactoringContribution(IJavaRefactorings.RENAME_PACKAGE);
-                RenameJavaElementDescriptor renameJavaElementDescriptor = (RenameJavaElementDescriptor) refactoringContribution.createDescriptor();
-                renameJavaElementDescriptor.setJavaElement(packageToRename);
-                renameJavaElementDescriptor.setNewName(PluginTools.getTestPackageName(getArguments().getNewName(), prefs));
+                IPackageFragment packageToRename = packageRoot.getPackageFragment(PluginTools.getTestPackageName(cutPackageName, prefs));
+                if(packageToRename != null && packageToRename.exists())
+                {
+                    RefactoringContribution refactoringContribution = RefactoringCore.getRefactoringContribution(IJavaRefactorings.RENAME_PACKAGE);
+                    RenameJavaElementDescriptor renameJavaElementDescriptor = (RenameJavaElementDescriptor) refactoringContribution.createDescriptor();
+                    renameJavaElementDescriptor.setJavaElement(packageToRename);
+                    renameJavaElementDescriptor.setNewName(PluginTools.getTestPackageName(getArguments().getNewName(), prefs));
 
-                RefactoringStatus refactoringStatus = new RefactoringStatus();
-                Refactoring renameRefactoring = renameJavaElementDescriptor.createRefactoring(refactoringStatus);
-                renameRefactoring.checkAllConditions(pm);
+                    RefactoringStatus refactoringStatus = new RefactoringStatus();
+                    Refactoring renameRefactoring = renameJavaElementDescriptor.createRefactoring(refactoringStatus);
+                    renameRefactoring.checkAllConditions(pm);
 
-                changes.add(renameRefactoring.createChange(pm));
+                    changes.add(renameRefactoring.createChange(pm));
+                }
             }
         }
 

--- a/org.moreunit.swtbot.test/META-INF/MANIFEST.MF
+++ b/org.moreunit.swtbot.test/META-INF/MANIFEST.MF
@@ -12,5 +12,6 @@ Require-Bundle: org.eclipse.swtbot.go,
  org.moreunit.test.dependencies,
  org.moreunit,
  org.eclipse.ltk.ui.refactoring,
- org.eclipse.jdt.ui
+ org.eclipse.jdt.ui,
+ org.eclipse.ui.ide
 Import-Package: org.eclipse.jdt.ui

--- a/org.moreunit.swtbot.test/pom.xml
+++ b/org.moreunit.swtbot.test/pom.xml
@@ -24,7 +24,7 @@
             <configuration>
               <useUIHarness>true</useUIHarness>
               <useUIThread>false</useUIThread>
-              <product>org.eclipse.sdk.ide</product>
+              <product>org.eclipse.platform.ide</product>
               <application>org.eclipse.ui.ide.workbench</application>
             </configuration>
         </plugin>

--- a/org.moreunit.swtbot.test/src/org/moreunit/ConditionCursorLine.java
+++ b/org.moreunit.swtbot.test/src/org/moreunit/ConditionCursorLine.java
@@ -1,0 +1,28 @@
+package org.moreunit;
+
+import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotEclipseEditor;
+import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;
+
+public class ConditionCursorLine extends DefaultCondition
+{
+    private final SWTBotEclipseEditor editor;
+    private final int lineNumberOfCursor;
+
+    public ConditionCursorLine(SWTBotEclipseEditor editor, int lineNumberOfCursor)
+    {
+        this.editor = editor;
+        this.lineNumberOfCursor = lineNumberOfCursor;
+    }
+
+    @Override
+    public boolean test() throws Exception
+    {
+        return editor.cursorPosition().line == lineNumberOfCursor;
+    }
+
+    @Override
+    public String getFailureMessage()
+    {
+        return "Failed to move the cursor in time at line " + lineNumberOfCursor;
+    }
+}

--- a/org.moreunit.swtbot.test/src/org/moreunit/JavaProjectSWTBotTestHelper.java
+++ b/org.moreunit.swtbot.test/src/org/moreunit/JavaProjectSWTBotTestHelper.java
@@ -10,6 +10,7 @@ import static org.junit.Assert.fail;
 
 import java.util.List;
 
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Shell;
@@ -33,6 +34,7 @@ import org.eclipse.swtbot.swt.finder.widgets.SWTBotText;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTree;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
 import org.eclipse.ui.IViewReference;
+import org.eclipse.ui.PlatformUI;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -40,6 +42,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
+import org.moreunit.log.LogHandler;
 import org.moreunit.test.context.TestContextRule;
 
 /**
@@ -128,6 +131,21 @@ public class JavaProjectSWTBotTestHelper
 
     protected void openResource(String resourceName)
     {
+        bot.waitUntil(new DefaultCondition()
+        {
+            
+            @Override
+            public boolean test() throws Exception
+            {
+                 return bot.activeShell().isEnabled() && bot.activeShell().isOpen() && Platform.isRunning() && PlatformUI.isWorkbenchRunning();
+            }
+            
+            @Override
+            public String getFailureMessage()
+            {
+                return "Application not fully ready";
+            }
+        });
         KeyboardFactory.getAWTKeyboard().pressShortcut(getCmdOrStrgKeyForShortcutsDependentOnPlattform() | SWT.SHIFT, 'r');
         SWTBotHelper.forceSWTBotShellsRecomputeNameCache(bot);
         bot.waitUntil(Conditions.shellIsActive("Open Resource"));

--- a/org.moreunit.swtbot.test/src/org/moreunit/JavaProjectSWTBotTestHelper.java
+++ b/org.moreunit.swtbot.test/src/org/moreunit/JavaProjectSWTBotTestHelper.java
@@ -10,9 +10,11 @@ import static org.junit.Assert.fail;
 
 import java.util.List;
 
-import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.swt.widgets.Tree;
@@ -34,7 +36,7 @@ import org.eclipse.swtbot.swt.finder.widgets.SWTBotText;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTree;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
 import org.eclipse.ui.IViewReference;
-import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.internal.ide.handlers.OpenResourceHandler;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -131,22 +133,22 @@ public class JavaProjectSWTBotTestHelper
 
     protected void openResource(String resourceName)
     {
-        bot.waitUntil(new DefaultCondition()
-        {
-            
+        Display.getDefault().asyncExec(new Runnable() {
+
             @Override
-            public boolean test() throws Exception
+            public void run()
             {
-                 return bot.activeShell().isEnabled() && bot.activeShell().isOpen() && Platform.isRunning() && PlatformUI.isWorkbenchRunning();
+                try
+                {
+                    new OpenResourceHandler().execute(new ExecutionEvent());
+                }
+                catch (ExecutionException e)
+                {
+                    LogHandler.getInstance().handleExceptionLog(e);
+                }
             }
-            
-            @Override
-            public String getFailureMessage()
-            {
-                return "Application not fully ready";
-            }
+           
         });
-        KeyboardFactory.getAWTKeyboard().pressShortcut(getCmdOrStrgKeyForShortcutsDependentOnPlattform() | SWT.SHIFT, 'r');
         SWTBotHelper.forceSWTBotShellsRecomputeNameCache(bot);
         bot.waitUntil(Conditions.shellIsActive("Open Resource"));
         SWTBotText searchField = new SWTBotText(bot.widget(widgetOfType(Text.class)));

--- a/org.moreunit.swtbot.test/src/org/moreunit/LinuxAndWindowsShortcutStrategy.java
+++ b/org.moreunit.swtbot.test/src/org/moreunit/LinuxAndWindowsShortcutStrategy.java
@@ -2,6 +2,7 @@ package org.moreunit;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swtbot.swt.finder.keyboard.KeyboardFactory;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotMenu;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
 
 public class LinuxAndWindowsShortcutStrategy extends ShortcutStrategy
@@ -16,7 +17,9 @@ public class LinuxAndWindowsShortcutStrategy extends ShortcutStrategy
 	@Override
 	public void openPreferences() 
 	{
-		bot.menu("Window").menu("Preferences").click();		
+		SWTBotMenu windowMenu = bot.menu("Window");
+		SWTBotMenu preferencesMenu = windowMenu.menu("Preferences");
+		preferencesMenu.click();
 	}
 
 	@Override

--- a/org.moreunit.swtbot.test/src/org/moreunit/MacShortcutStrategy.java
+++ b/org.moreunit.swtbot.test/src/org/moreunit/MacShortcutStrategy.java
@@ -4,6 +4,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swtbot.eclipse.finder.waits.Conditions;
 import org.eclipse.swtbot.swt.finder.keyboard.KeyboardFactory;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
+import org.moreunit.log.LogHandler;
 
 public class MacShortcutStrategy extends ShortcutStrategy 
 {
@@ -16,6 +17,7 @@ public class MacShortcutStrategy extends ShortcutStrategy
 	@Override
 	public void openPreferences() 
 	{
+	    LogHandler.getInstance().handleInfoLog("Opening Preferences usign Mac Shortcut command");
 		KeyboardFactory.getAWTKeyboard().pressShortcut(SWT.COMMAND, ',');		
 	}
 	

--- a/org.moreunit.swtbot.test/src/org/moreunit/ShortcutStrategy.java
+++ b/org.moreunit.swtbot.test/src/org/moreunit/ShortcutStrategy.java
@@ -5,6 +5,7 @@ import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
 import org.eclipse.swtbot.swt.finder.SWTBot;
 import org.eclipse.swtbot.swt.finder.keyboard.KeyboardFactory;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
+import org.moreunit.log.LogHandler;
 
 
 public abstract class ShortcutStrategy 
@@ -26,6 +27,7 @@ public abstract class ShortcutStrategy
 	protected static boolean isRunningOnLinuxOrWindows() 
 	{
 		String osName = System.getProperty("os.name");
+		LogHandler.getInstance().handleInfoLog("os.name used to define on which Platform it is running "+ osName);
         return osName.contains("Linux") || osName.contains("Win");
 	}
 	

--- a/org.moreunit.swtbot.test/src/org/moreunit/create/MethodCreationTest.java
+++ b/org.moreunit.swtbot.test/src/org/moreunit/create/MethodCreationTest.java
@@ -7,6 +7,7 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotEclipseEditor;
 import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;
 import org.junit.Test;
+import org.moreunit.ConditionCursorLine;
 import org.moreunit.JavaProjectSWTBotTestHelper;
 import org.moreunit.test.context.Project;
 import org.moreunit.test.context.Properties;
@@ -31,6 +32,7 @@ public class MethodCreationTest extends JavaProjectSWTBotTestHelper
     	// move cursor to method
     	int lineNumberOfMethod = 6;
 		cutEditor.navigateTo(lineNumberOfMethod, 9);
+		bot.waitUntil(new ConditionCursorLine(cutEditor, lineNumberOfMethod));
 		
 		getShortcutStrategy().pressGenerateShortcut();
 		
@@ -57,6 +59,7 @@ public class MethodCreationTest extends JavaProjectSWTBotTestHelper
 		// move cursor to method
     	int lineNumberOfMethod = 9;
     	testcaseEditor.navigateTo(lineNumberOfMethod, 9);
+    	bot.waitUntil(new ConditionCursorLine(testcaseEditor, lineNumberOfMethod));
 		
 		getShortcutStrategy().pressGenerateShortcut();
 

--- a/org.moreunit.swtbot.test/src/org/moreunit/jump/BasicJumpTest.java
+++ b/org.moreunit.swtbot.test/src/org/moreunit/jump/BasicJumpTest.java
@@ -7,6 +7,7 @@ import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotEditor;
 import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;
 import org.junit.Before;
 import org.junit.Test;
+import org.moreunit.ConditionCursorLine;
 import org.moreunit.JavaProjectSWTBotTestHelper;
 import org.moreunit.test.context.Context;
 import org.moreunit.test.context.Project;
@@ -74,6 +75,7 @@ public class BasicJumpTest extends JavaProjectSWTBotTestHelper
     	// move cursor to method
     	int lineNumberOfMethod = 6;
 		cutEditor.navigateTo(lineNumberOfMethod, 9);
+		bot.waitUntil(new ConditionCursorLine(cutEditor, lineNumberOfMethod));
     	getShortcutStrategy().pressJumpShortcut();
     	
     	final int lineNumberOfTestMethod = 7;
@@ -83,8 +85,8 @@ public class BasicJumpTest extends JavaProjectSWTBotTestHelper
             @Override
             public boolean test() throws Exception
             {
-                SWTBotEclipseEditor testEditor = BasicJumpTest.bot.activeEditor().toTextEditor();
-                return testEditor.cursorPosition().line == lineNumberOfTestMethod;
+                SWTBotEclipseEditor textEditor = BasicJumpTest.bot.activeEditor().toTextEditor();
+                return textEditor.cursorPosition().line == lineNumberOfTestMethod;
             }
             
             @Override

--- a/org.moreunit.swtbot.test/src/org/moreunit/jump/BasicJumpTest.java
+++ b/org.moreunit.swtbot.test/src/org/moreunit/jump/BasicJumpTest.java
@@ -4,6 +4,7 @@ import static org.fest.assertions.Assertions.assertThat;
 
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotEclipseEditor;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotEditor;
+import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;
 import org.junit.Before;
 import org.junit.Test;
 import org.moreunit.JavaProjectSWTBotTestHelper;
@@ -75,8 +76,22 @@ public class BasicJumpTest extends JavaProjectSWTBotTestHelper
 		cutEditor.navigateTo(lineNumberOfMethod, 9);
     	getShortcutStrategy().pressJumpShortcut();
     	
-    	SWTBotEclipseEditor testEditor = bot.activeEditor().toTextEditor();
     	final int lineNumberOfTestMethod = 7;
-		assertThat(testEditor.cursorPosition().line).isEqualTo(lineNumberOfTestMethod);
+    	bot.waitUntil(new DefaultCondition()
+        {
+    	    
+            @Override
+            public boolean test() throws Exception
+            {
+                SWTBotEclipseEditor testEditor = BasicJumpTest.bot.activeEditor().toTextEditor();
+                return testEditor.cursorPosition().line == lineNumberOfTestMethod;
+            }
+            
+            @Override
+            public String getFailureMessage()
+            {
+                return "It has not jumped to the right line number inside the test class.";
+            }
+        });
     }
 }

--- a/org.moreunit.swtbot.test/src/org/moreunit/refactoring/MoveMethodTest.java
+++ b/org.moreunit.swtbot.test/src/org/moreunit/refactoring/MoveMethodTest.java
@@ -8,6 +8,7 @@ import org.eclipse.swtbot.eclipse.finder.waits.Conditions;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotEclipseEditor;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
 import org.junit.Test;
+import org.moreunit.ConditionCursorLine;
 import org.moreunit.JavaProjectSWTBotTestHelper;
 import org.moreunit.test.context.Preferences;
 import org.moreunit.test.context.Project;
@@ -32,6 +33,7 @@ public class MoveMethodTest extends JavaProjectSWTBotTestHelper
 		cutEditor.setFocus();
 		int lineNumberOfMethodSignature = 4;
 		cutEditor.navigateTo(lineNumberOfMethodSignature, 27);
+		bot.waitUntil(new ConditionCursorLine(cutEditor, lineNumberOfMethodSignature));
 		getShortcutStrategy().pressMoveShortcut();
 		bot.waitUntil(Conditions.shellIsActive("Move Static Members"));
 		bot.comboBox().setText("testing.TheMoon");

--- a/org.moreunit.swtbot.test/src/org/moreunit/refactoring/MoveMethodTest.java
+++ b/org.moreunit.swtbot.test/src/org/moreunit/refactoring/MoveMethodTest.java
@@ -3,9 +3,11 @@ package org.moreunit.refactoring;
 import static org.fest.assertions.Assertions.assertThat;
 
 import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.swtbot.eclipse.finder.waits.Conditions;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotEclipseEditor;
+import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
 import org.junit.Test;
 import org.moreunit.ConditionCursorLine;
@@ -42,7 +44,23 @@ public class MoveMethodTest extends JavaProjectSWTBotTestHelper
 		bot.waitUntil(Conditions.shellCloses(moveDialog), 10000);
 		
 		// assert that testmethod moved from TheWorldTest to TheMoonTest
-		ICompilationUnit testBeforeMove = context.getCompilationUnit("testing.TheWorldTest");
+		final ICompilationUnit testBeforeMove = context.getCompilationUnit("testing.TheWorldTest");
+		bot.waitUntil(new DefaultCondition()
+        {
+            
+            @Override
+            public boolean test() throws Exception
+            {
+                IMethod[] methods = testBeforeMove.findPrimaryType().getMethods();
+                return methods == null || methods.length == 0;
+            }
+            
+            @Override
+            public String getFailureMessage()
+            {
+                return "Method not deleted from original class";
+            }
+        });
 		assertThat(testBeforeMove.findPrimaryType().getMethods()).isEmpty();
 		ICompilationUnit testAfterMove = context.getCompilationUnit("testing.TheMoonTest");
 		assertThat(testAfterMove.findPrimaryType().getMethods()).onProperty("elementName").containsOnly("testGetNumber1");

--- a/org.moreunit.swtbot.test/src/org/moreunit/refactoring/RenameClassTest.java
+++ b/org.moreunit.swtbot.test/src/org/moreunit/refactoring/RenameClassTest.java
@@ -3,6 +3,7 @@ package org.moreunit.refactoring;
 import static org.fest.assertions.Assertions.assertThat;
 
 import org.eclipse.swtbot.eclipse.finder.waits.Conditions;
+import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
 import org.junit.Test;
@@ -44,9 +45,24 @@ public class RenameClassTest extends JavaProjectSWTBotTestHelper
 	
 	private void renameSomeClassToAnyClassAndWaitUntilFinished() 
 	{
-		SWTBotTreeItem packageItem = selectAndReturnPackageWithName("org");
+		final SWTBotTreeItem packageItem = selectAndReturnPackageWithName("org");
 		packageItem.expand();
 		packageItem.getNode("SomeClass.java").select();
+		bot.waitUntil(new DefaultCondition()
+        {
+            
+            @Override
+            public boolean test() throws Exception
+            {
+                return packageItem.getNode("SomeClass.java").isSelected();
+            }
+            
+            @Override
+            public String getFailureMessage()
+            {
+                return "Node SomeClass.java not selected";
+            }
+        });
 		getShortcutStrategy().pressRenameShortcut();
 		bot.textWithLabel("New name:").setText("AnyClass");
 		bot.button("Finish").click();

--- a/org.moreunit.swtbot.test/src/org/moreunit/refactoring/RenameMethodTest.java
+++ b/org.moreunit.swtbot.test/src/org/moreunit/refactoring/RenameMethodTest.java
@@ -11,6 +11,7 @@ import org.eclipse.swtbot.eclipse.finder.waits.Conditions;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotEclipseEditor;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
 import org.junit.Test;
+import org.moreunit.ConditionCursorLine;
 import org.moreunit.JavaProjectSWTBotTestHelper;
 import org.moreunit.SWTBotHelper;
 import org.moreunit.test.context.Preferences;
@@ -36,6 +37,7 @@ public class RenameMethodTest extends JavaProjectSWTBotTestHelper
 		cutEditor.setFocus();
 		int lineNumberOfMethodSignature = 4;
 		cutEditor.navigateTo(lineNumberOfMethodSignature, 20);
+		bot.waitUntil(new ConditionCursorLine(cutEditor, lineNumberOfMethodSignature));
 
 		pressRenameShortcutTwiceAndWaitForDialog();
 		renameMethodAndWaitUntilFinished();

--- a/org.moreunit.swtbot.test/src/org/moreunit/settings/PreferencesTest.java
+++ b/org.moreunit.swtbot.test/src/org/moreunit/settings/PreferencesTest.java
@@ -4,6 +4,7 @@ import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.swtbot.eclipse.finder.waits.Conditions;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotText;
 import org.junit.Test;
@@ -47,7 +48,9 @@ public class PreferencesTest extends JavaProjectSWTBotTestHelper
 
     private void saveAndClosePrefs()
     {
-        bot.button("OK").click();
+        // in newer version (at least 4.8), the label has been changed and is stored in a preference
+        String label = JFaceResources.getString("PreferencesDialog.okButtonLabel");
+        bot.button("PreferencesDialog.okButtonLabel".equals(label)? "OK" : label).click();
     }
 
     @Test

--- a/org.moreunit.swtbot.test/src/org/moreunit/settings/PreferencesTest.java
+++ b/org.moreunit.swtbot.test/src/org/moreunit/settings/PreferencesTest.java
@@ -18,7 +18,7 @@ public class PreferencesTest extends JavaProjectSWTBotTestHelper
     private void openPreferencesAndSelectMoreUnitPage()
     {
         getShortcutStrategy().openPreferences();
-        bot.waitUntil(Conditions.shellIsActive("Preferences"));
+        bot.waitUntil(Conditions.shellIsActive("Preferences"), 20000);
         bot.shell("Preferences").activate();
         bot.shell("Preferences").setFocus();
         bot.tree().expandNode("MoreUnit").select("Java");

--- a/org.moreunit.swtbot.test/src/org/moreunit/settings/PropertiesTest.java
+++ b/org.moreunit.swtbot.test/src/org/moreunit/settings/PropertiesTest.java
@@ -5,6 +5,7 @@ import static org.fest.assertions.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swtbot.eclipse.finder.waits.Conditions;
 import org.eclipse.swtbot.swt.finder.finders.UIThreadRunnable;
@@ -68,7 +69,9 @@ public class PropertiesTest extends JavaProjectSWTBotTestHelper
 
     private void saveAndCloseProps()
     {
-        bot.button("OK").click();
+        // in newer version (at least 4.8), the label has been changed and is stored in a preference
+        String label = JFaceResources.getString("PreferencesDialog.okButtonLabel");
+        bot.button("PreferencesDialog.okButtonLabel".equals(label)? "OK" : label).click();
     }
 
     @Before


### PR DESCRIPTION
I needed to upgrade to latest TP to investigate failures on CI of SWTBot test.
Tests are now launched with 4.8 TP. I think that given available resources to work on the project launching test against the not-too-old version is better

This PR is then doing 2 things:
- providing a Travis CI config
- upgrading to 4.8 TP (and using it for test execution)