### PR TITLE
Fix target platforms (closes #86)

### DIFF
--- a/org.moreunit.build/eclipse-4.3.target
+++ b/org.moreunit.build/eclipse-4.3.target
@@ -3,7 +3,7 @@
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.testng.eclipse.feature.group" version="6.9.11.201604020423"/>
-<repository location="http://beust.com/eclipse"/>
+<repository location="https://dl.bintray.com/testng-team/testng-eclipse-release/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.sdk.ide" version="4.3.2.M20140221-1700"/>

--- a/org.moreunit.build/eclipse-4.4.target
+++ b/org.moreunit.build/eclipse-4.4.target
@@ -3,7 +3,7 @@
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.testng.eclipse.feature.group" version="6.9.11.201604020423"/>
-<repository location="http://beust.com/eclipse"/>
+<repository location="https://dl.bintray.com/testng-team/testng-eclipse-release/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.sdk.ide" version="4.4.2.M20150204-1700"/>

--- a/org.moreunit.build/eclipse-4.5.target
+++ b/org.moreunit.build/eclipse-4.5.target
@@ -3,7 +3,7 @@
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.testng.eclipse.feature.group" version="6.9.11.201604020423"/>
-<repository location="http://beust.com/eclipse"/>
+<repository location="https://dl.bintray.com/testng-team/testng-eclipse-release/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.sdk.ide" version="4.5.2.M20160212-1500"/>

--- a/org.moreunit.build/eclipse-4.6.target
+++ b/org.moreunit.build/eclipse-4.6.target
@@ -3,7 +3,7 @@
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.testng.eclipse.feature.group" version="6.9.11.201604020423"/>
-<repository location="http://beust.com/eclipse"/>
+<repository location="https://dl.bintray.com/testng-team/testng-eclipse-release/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.4.0.201604200752"/>

--- a/org.moreunit.build/eclipse-4.7.target
+++ b/org.moreunit.build/eclipse-4.7.target
@@ -3,7 +3,7 @@
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.testng.eclipse.feature.group" version="6.9.11.201604020423"/>
-<repository location="http://beust.com/eclipse"/>
+<repository location="https://dl.bintray.com/testng-team/testng-eclipse-release/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.6.0.201706141832"/>

--- a/org.moreunit.build/eclipse-4.8.target
+++ b/org.moreunit.build/eclipse-4.8.target
@@ -3,7 +3,7 @@
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.testng.eclipse.feature.group" version="6.14.0.201802161500"/>
-<repository location="http://beust.com/eclipse"/>
+<repository location="https://dl.bintray.com/testng-team/testng-eclipse-release/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.7.0.201806111355"/>


### PR DESCRIPTION
beust.com no longer contains the testng feature. Use bintray, where this
seems to be hosted now.