### PR TITLE
use another JDK for Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,10 @@ language: java
 env: 
   global:
   - DISPLAY=:99
+services:
+  - xvfb
 before_script:
   - cd org.moreunit.build
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
 script: mvn verify -fae
 jdk: 
   - openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
   - sleep 3 # give xvfb some time to start
 script: mvn verify -fae
 jdk: 
-  - oraclejdk8
+  - openjdk8
 cache:
   directories:
     - $HOME/.m2

--- a/org.moreunit.build/eclipse-4.3.target
+++ b/org.moreunit.build/eclipse-4.3.target
@@ -3,7 +3,7 @@
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.testng.eclipse.feature.group" version="6.9.11.201604020423"/>
-<repository location="http://beust.com/eclipse"/>
+<repository location="https://dl.bintray.com/testng-team/testng-eclipse-release/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.sdk.ide" version="4.3.2.M20140221-1700"/>

--- a/org.moreunit.build/eclipse-4.4.target
+++ b/org.moreunit.build/eclipse-4.4.target
@@ -3,7 +3,7 @@
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.testng.eclipse.feature.group" version="6.9.11.201604020423"/>
-<repository location="http://beust.com/eclipse"/>
+<repository location="https://dl.bintray.com/testng-team/testng-eclipse-release/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.sdk.ide" version="4.4.2.M20150204-1700"/>

--- a/org.moreunit.build/eclipse-4.5.target
+++ b/org.moreunit.build/eclipse-4.5.target
@@ -3,7 +3,7 @@
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.testng.eclipse.feature.group" version="6.9.11.201604020423"/>
-<repository location="http://beust.com/eclipse"/>
+<repository location="https://dl.bintray.com/testng-team/testng-eclipse-release/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.sdk.ide" version="4.5.2.M20160212-1500"/>

--- a/org.moreunit.build/eclipse-4.6.target
+++ b/org.moreunit.build/eclipse-4.6.target
@@ -3,7 +3,7 @@
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.testng.eclipse.feature.group" version="6.9.11.201604020423"/>
-<repository location="http://beust.com/eclipse"/>
+<repository location="https://dl.bintray.com/testng-team/testng-eclipse-release/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.4.0.201604200752"/>

--- a/org.moreunit.build/eclipse-4.7.target
+++ b/org.moreunit.build/eclipse-4.7.target
@@ -3,7 +3,7 @@
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.testng.eclipse.feature.group" version="6.9.11.201604020423"/>
-<repository location="http://beust.com/eclipse"/>
+<repository location="https://dl.bintray.com/testng-team/testng-eclipse-release/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.6.0.201706141832"/>

--- a/org.moreunit.build/eclipse-4.8.target
+++ b/org.moreunit.build/eclipse-4.8.target
@@ -2,8 +2,8 @@
 <?pde version="3.8"?><target name="eclipse-4.8" sequenceNumber="9">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.testng.eclipse.feature.group" version="6.14.0.201802161500"/>
-<repository location="https://dl.bintray.com/testng-team/testng-eclipse-release/"/>
+<unit id="org.testng.eclipse.feature.group" version="6.14.3.201902250526"/>
+<repository location="https://dl.bintray.com/testng-team/testng-eclipse-release/updatesites/6.14.3.201902250526/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.7.0.201806111355"/>

--- a/org.moreunit.build/eclipse-4.8.target
+++ b/org.moreunit.build/eclipse-4.8.target
@@ -3,7 +3,7 @@
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.testng.eclipse.feature.group" version="6.14.0.201802161500"/>
-<repository location="http://beust.com/eclipse"/>
+<repository location="https://dl.bintray.com/testng-team/testng-eclipse-release/"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.swtbot.eclipse.feature.group" version="2.7.0.201806111355"/>


### PR DESCRIPTION
Oracle JDK 8 is not available anymore on latest Travis

Signed-off-by: Aurélien Pupier <apupier@redhat.com>