### PR TITLE
Java 11 runtime support (fixes #63, #93 and #68)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ docs/.project
 org.moreunit.*/classes/
 org.moreunit.*/target/
 Thumbs.db
+
+# non osgi libs for JRE11+ compatibility
+org.moreunit.mock*/lib/

--- a/org.moreunit.mock.test/META-INF/MANIFEST.MF
+++ b/org.moreunit.mock.test/META-INF/MANIFEST.MF
@@ -8,3 +8,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-Vendor: MoreUnit.org
 Require-Bundle: org.moreunit.test.dependencies,
  org.junit;bundle-version="4.11.0"
+Bundle-ClassPath: .,
+ lib/jakarta.activation.jar,
+ lib/jakarta.xml.bind-api.jar,
+ lib/jaxb-impl.jar

--- a/org.moreunit.mock.test/build.properties
+++ b/org.moreunit.mock.test/build.properties
@@ -2,6 +2,6 @@ source.. = test/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
-               lib_back/jakarta.activation.jar,\
-               lib_back/jakarta.xml.bind-api.jar,\
-               lib_back/jaxb-impl.jar
+               lib/jakarta.activation.jar,\
+               lib/jakarta.xml.bind-api.jar,\
+               lib/jaxb-impl.jar

--- a/org.moreunit.mock.test/build.properties
+++ b/org.moreunit.mock.test/build.properties
@@ -1,4 +1,7 @@
 source.. = test/
 output.. = bin/
 bin.includes = META-INF/,\
-               .
+               .,\
+               lib_back/jakarta.activation.jar,\
+               lib_back/jakarta.xml.bind-api.jar,\
+               lib_back/jaxb-impl.jar

--- a/org.moreunit.mock.test/pom.xml
+++ b/org.moreunit.mock.test/pom.xml
@@ -20,6 +20,43 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.10</version>
+        <executions>
+          <execution>
+            <id>copy-libraries</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <item>
+                  <groupId>com.sun.activation</groupId>
+                  <artifactId>jakarta.activation</artifactId>
+                  <version>1.2.2</version>
+                </item>
+                <item>
+                  <groupId>jakarta.xml.bind</groupId>
+                  <artifactId>jakarta.xml.bind-api</artifactId>
+                  <version>2.3.3</version>
+                </item>
+                <item>
+                  <groupId>com.sun.xml.bind</groupId>
+                  <artifactId>jaxb-impl</artifactId>
+                  <version>2.3.3</version>
+                </item>
+              </artifactItems>
+              <outputDirectory>lib</outputDirectory>
+              <stripVersion>true</stripVersion>
+              <overWriteReleases>true</overWriteReleases>
+              <overWriteSnapshots>true</overWriteSnapshots>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <executions>
           <!-- activates simple unit test run during "test" phase -->

--- a/org.moreunit.mock/META-INF/MANIFEST.MF
+++ b/org.moreunit.mock/META-INF/MANIFEST.MF
@@ -17,4 +17,7 @@ Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-Vendor: MoreUnit.org
 Bundle-ClassPath: .,
+ lib/jakarta.activation.jar,
+ lib/jakarta.xml.bind-api.jar,
+ lib/jaxb-impl.jar,
  resources/

--- a/org.moreunit.mock/build.properties
+++ b/org.moreunit.mock/build.properties
@@ -6,6 +6,9 @@ bin.includes = about.ini,\
                META-INF/,\
                .,\
                plugin.xml,\
-               resources/templates/
+               resources/templates/, \
+               lib/jakarta.activation.jar, \
+               lib/jakarta.xml.bind-api.jar, \
+               lib/jaxb-impl.jar
 jre.compilation.profile = JavaSE-1.6
 qualifier=none

--- a/org.moreunit.mock/pom.xml
+++ b/org.moreunit.mock/pom.xml
@@ -14,4 +14,47 @@
   <packaging>eclipse-plugin</packaging>
 
   <name>${project.artifactId}</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.10</version>
+        <executions>
+          <execution>
+            <id>copy-libraries</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <item>
+                  <groupId>com.sun.activation</groupId>
+                  <artifactId>jakarta.activation</artifactId>
+                  <version>1.2.2</version>
+                </item>
+                <item>
+                  <groupId>jakarta.xml.bind</groupId>
+                  <artifactId>jakarta.xml.bind-api</artifactId>
+                  <version>2.3.3</version>
+                </item>
+                <item>
+                  <groupId>com.sun.xml.bind</groupId>
+                  <artifactId>jaxb-impl</artifactId>
+                  <version>2.3.3</version>
+                </item>
+              </artifactItems>
+              <outputDirectory>lib</outputDirectory>
+              <stripVersion>true</stripVersion>
+              <overWriteReleases>true</overWriteReleases>
+              <overWriteSnapshots>true</overWriteSnapshots>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project> 


### PR DESCRIPTION
Hotfix for https://github.com/MoreUnit/MoreUnit-Eclipse/issues/63, https://github.com/MoreUnit/MoreUnit-Eclipse/issues/93 and https://github.com/MoreUnit/MoreUnit-Eclipse/issues/68 

Plugin must be build with a JDK8 but can now run with a JRE11.

Solution from
https://vainolo.com/2016/01/23/adding-jar-dependencies-to-an-eclipse-plugin-tycho-build/
and https://stackoverflow.com/questions/28542595/how-to-embed-a-library-jar-in-an-osgi-bundle-using-tycho/30872071#30872071 to embed JAXB runtime as non OSGI libs.
