### PR TITLE
Fix strikethrough in release notes

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -481,14 +481,14 @@
 		<article id="releasenotes">
 			<header>Release Notes</header>
 			<section>
-			<h2 style="text-decoration: line-through">2021-08-30: Version 3.3.0</h2>
+			<h2>2021-08-30: Version 3.3.0</h2>
 			<ul>
 			<li>Support Eclipse 2021-06</li>
 			<li>Java 11 as runtime is now fully supported</li>
 			<li>Drop support of previous Eclipse versions. Eclipse 2021-06 is now required</li>
 			</ul>
 			
-				<h2>2018-11-17: Version 3.2.1</h2>
+				<h2 style="text-decoration: line-through">2018-11-17: Version 3.2.1</h2>
 				<p><em>Identical to version 3.2.0, not an actual release but rather a test of our release tools.</em></p>
 		  	<h2>2018-11-17: Version 3.2.0</h2>
 	  		<ul>


### PR DESCRIPTION
this is to fix this strikethrough on 3.3.0 release which should be on 3.2.1

![Screenshot from 2021-08-30 11-23-14](https://user-images.githubusercontent.com/1105127/131317600-3548404e-eb44-4f79-9c85-8bbe8aa352b8.png)
