### PR TITLE
fix #84: property page layout

### DIFF
--- a/org.moreunit.plugin/src/org/moreunit/properties/MoreUnitPropertyPage.java
+++ b/org.moreunit.plugin/src/org/moreunit/properties/MoreUnitPropertyPage.java
@@ -7,6 +7,8 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.custom.CTabFolder;
+import org.eclipse.swt.custom.CTabItem;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionEvent;
@@ -16,8 +18,6 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.TabFolder;
-import org.eclipse.swt.widgets.TabItem;
 import org.eclipse.ui.dialogs.PropertyPage;
 import org.eclipse.ui.preferences.ScopedPreferenceStore;
 import org.moreunit.log.LogHandler;
@@ -29,7 +29,7 @@ import org.moreunit.preferences.Preferences;
 public class MoreUnitPropertyPage extends PropertyPage
 {
     private Button projectSpecificSettingsCheckbox;
-    private TabFolder tabFolder;
+    private CTabFolder tabFolder;
 
     private UnitSourceFolderBlock firstTabUnitSourceFolder;
     private OtherMoreunitPropertiesBlock secondTabOtherProperties;
@@ -78,13 +78,13 @@ public class MoreUnitPropertyPage extends PropertyPage
 
     private void createTabContent(Composite parent)
     {
-        tabFolder = new TabFolder(parent, SWT.BORDER);
-        TabItem sourceFolderItem = new TabItem(tabFolder, SWT.NONE);
+        tabFolder = new CTabFolder(parent, SWT.BORDER | SWT.TOP);
+        CTabItem sourceFolderItem = new CTabItem(tabFolder, SWT.NONE);
         sourceFolderItem.setText("Test source folder");
         firstTabUnitSourceFolder = new UnitSourceFolderBlock(getJavaProject(), this);
         sourceFolderItem.setControl(fixesFirstTabStyle(firstTabUnitSourceFolder.getControl(tabFolder)));
 
-        TabItem otherFolderItem = new TabItem(tabFolder, SWT.NONE);
+        CTabItem otherFolderItem = new CTabItem(tabFolder, SWT.NONE);
         otherFolderItem.setText("Other");
         secondTabOtherProperties = new OtherMoreunitPropertiesBlock(getJavaProject());
         otherFolderItem.setControl(fixesSecondTabStyle(secondTabOtherProperties.getControl(tabFolder, true)));
@@ -104,6 +104,7 @@ public class MoreUnitPropertyPage extends PropertyPage
         GridData gridData = new GridData(GridData.FILL_BOTH);
         gridData.heightHint = otherFolderItem.getControl().computeSize(SWT.DEFAULT, SWT.DEFAULT).y;
         tabFolder.setLayoutData(gridData);
+        tabFolder.setSelection(0);
 
         setEnabled(shouldUseProjectspecificSettings());
     }

--- a/org.moreunit.swtbot.test/src/org/moreunit/settings/PropertiesTest.java
+++ b/org.moreunit.swtbot.test/src/org/moreunit/settings/PropertiesTest.java
@@ -210,7 +210,7 @@ public class PropertiesTest extends JavaProjectSWTBotTestHelper
     {
         openProjectPropertiesAndSelectMoreUnitPage();
         bot.checkBox("Use project specific settings").select();
-        bot.tabItem("Other").activate();
+        bot.cTabItem("Other").activate();
     }
     
     @Test


### PR DESCRIPTION
Use CTabFolder/Item instead of TabFolder/Item. Those respect the system
colors.

before: 
![image](https://user-images.githubusercontent.com/406876/131330285-0e3d79e8-a086-4e69-bc63-788b8d4ac197.png)

after: 
![image](https://user-images.githubusercontent.com/406876/131330313-28ed48ce-f88b-4ffc-9b04-a0749b7d00c7.png)
