### PR TITLE
fix #85 : generate JUnit 5 tests with Package-scope

### DIFF
--- a/org.moreunit.extension/src/org/moreunit/extension/handler/ModifyTestMethodParticipator.java
+++ b/org.moreunit.extension/src/org/moreunit/extension/handler/ModifyTestMethodParticipator.java
@@ -80,7 +80,7 @@ public class ModifyTestMethodParticipator implements ITestMethodParticipator {
 	 * Access modifiers for methods linked in JavaDoc.
 	 */
 	private enum JavaDocVisibility {
-	Public, Protected, Package, Private
+		Public, Protected, Package, Private
 	}
 
 	/**
@@ -307,6 +307,10 @@ public class ModifyTestMethodParticipator implements ITestMethodParticipator {
 				addImport(astRoot, "org.junit.Test", false);
 				addImport(astRoot, "org.junit.Assert", false);
 				addImport(astRoot, "org.junit.Assert.fail", true);
+				break;
+			case JUNIT_5:
+				addImport(astRoot, "org.junit.jupiter.api.Assertions.fail", true);
+				addImport(astRoot, "org.junit.jupiter.api.Test", false);
 				break;
 			case TESTNG:
 				addImport(astRoot, "org.testng.annotations.Test", false);

--- a/org.moreunit.plugin/src/org/moreunit/wizards/MoreUnitWizardPageOne.java
+++ b/org.moreunit.plugin/src/org/moreunit/wizards/MoreUnitWizardPageOne.java
@@ -1345,6 +1345,10 @@ public class MoreUnitWizardPageOne extends NewTypeWizardPage
             modifiers &= ~ F_PRIVATE;
             modifiers &= ~ F_PROTECTED;
         }
+        else if(unit5Toggle.getSelection())
+        {
+            modifiers &= ~ F_PUBLIC;
+        }
 
         return modifiers;
     }

--- a/org.moreunit.swtbot.test/src/org/moreunit/create/ClassCreationTest.java
+++ b/org.moreunit.swtbot.test/src/org/moreunit/create/ClassCreationTest.java
@@ -2,6 +2,7 @@ package org.moreunit.create;
 
 import static org.fest.assertions.Assertions.assertThat;
 
+import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotEclipseEditor;
@@ -59,7 +60,9 @@ public class ClassCreationTest extends JavaProjectSWTBotTestHelper
                 return "Test not created testing.TheWorldTest";
             }
         }, 20000);
-        assertThat(context.getCompilationUnit("testing.TheWorldTest").findPrimaryType().getFlags()).isEqualTo(FLAG_DEFAULT_PACKAGE);
+        ICompilationUnit compilationUnitOfTest = context.getCompilationUnit("testing.TheWorldTest");
+        assertThat(compilationUnitOfTest.findPrimaryType().getFlags()).isEqualTo(FLAG_DEFAULT_PACKAGE);
+        assertThat(compilationUnitOfTest.getImport("org.junit.jupiter.api.Test").exists()).isTrue();
     }
 
     private void moveCursorToMethod()

--- a/org.moreunit.swtbot.test/src/org/moreunit/create/ClassCreationTest.java
+++ b/org.moreunit.swtbot.test/src/org/moreunit/create/ClassCreationTest.java
@@ -1,0 +1,72 @@
+package org.moreunit.create;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jface.dialogs.IDialogConstants;
+import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotEclipseEditor;
+import org.eclipse.swtbot.swt.finder.junit.SWTBotJunit4ClassRunner;
+import org.eclipse.swtbot.swt.finder.waits.Conditions;
+import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.moreunit.ConditionCursorLine;
+import org.moreunit.JavaProjectSWTBotTestHelper;
+import org.moreunit.test.context.Project;
+import org.moreunit.test.context.Properties;
+import org.moreunit.test.context.TestType;
+
+@RunWith(SWTBotJunit4ClassRunner.class)
+public class ClassCreationTest extends JavaProjectSWTBotTestHelper
+{
+    private static final int FLAG_DEFAULT_PACKAGE = 0;
+
+    @Project(mainSrc = "MethodCreation_class_with_method.txt",
+            mainSrcFolder = "src",
+            testSrcFolder = "junit",
+            properties = @Properties(
+                                     testType = TestType.JUNIT5,
+                                     testClassNameTemplate = "${srcFile}Test",
+                                     testMethodPrefix = true))
+    @Test
+    public void should_create_test_with_default_package_for_junit5() throws JavaModelException
+    {
+        openResource("TheWorld.java");
+        moveCursorToMethod();
+
+        getShortcutStrategy().pressGenerateShortcut();
+        
+        bot.waitUntil(Conditions.shellIsActive("New JUnit Test Case"));
+        
+        bot.button(IDialogConstants.FINISH_LABEL).click();
+        
+        bot.waitUntil(new DefaultCondition()
+        {
+            @Override
+            public boolean test() throws Exception
+            {
+                try {
+                    context.getCompilationUnit("testing.TheWorldTest");
+                } catch (IllegalArgumentException ex) {
+                    return false;
+                }
+                return true;
+            }
+
+            @Override
+            public String getFailureMessage()
+            {
+                return "Test not created testing.TheWorldTest";
+            }
+        }, 20000);
+        assertThat(context.getCompilationUnit("testing.TheWorldTest").findPrimaryType().getFlags()).isEqualTo(FLAG_DEFAULT_PACKAGE);
+    }
+
+    private void moveCursorToMethod()
+    {
+        SWTBotEclipseEditor cutEditor = bot.activeEditor().toTextEditor();
+        int lineNumberOfMethod = 6;
+        cutEditor.navigateTo(lineNumberOfMethod, 9);
+        bot.waitUntil(new ConditionCursorLine(cutEditor, lineNumberOfMethod));
+    }
+}


### PR DESCRIPTION
applied same trick than in JDT:
https://git.eclipse.org/r/plugins/gitiles/jdt/eclipse.jdt.ui/+/refs/heads/master/org.eclipse.jdt.junit/src/org/eclipse/jdt/junit/wizards/NewTestCaseWizardPageOne.java#1430

Signed-off-by: Aurélien Pupier <apupier@redhat.com>