### PR TITLE
Fix path to parent pom for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
 - package-ecosystem: maven
-  directory: "/"
+  directory: "/org.moreunit.build"
   schedule:
     interval: daily
   open-pull-requests-limit: 10


### PR DESCRIPTION
fix #107

Signed-off-by: Aurélien Pupier <apupier@redhat.com>