### PR TITLE
Guw/jaxb reactivate tests

### DIFF
--- a/org.moreunit.mock.test/pom.xml
+++ b/org.moreunit.mock.test/pom.xml
@@ -14,38 +14,4 @@
   <packaging>eclipse-test-plugin</packaging>
 
   <name>${project.artifactId}</name>
-
-  <!-- TODO Nicolas: we could merge org.moreunit.mock.test and org.moreunit.mock.it and run both sets of tests (unit/integration) differently -->
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <executions>
-          <!-- activates simple unit test run during "test" phase -->
-          <execution>
-            <id>test</id>
-            <phase>test</phase>
-            <configuration>
-              <testClassesDirectory>${project.build.outputDirectory}</testClassesDirectory>
-            </configuration>
-            <goals>
-              <goal>test</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.eclipse.tycho</groupId>
-        <artifactId>tycho-surefire-plugin</artifactId>
-        <executions>
-          <!-- deactivates default integration test run during "verify" phase -->
-          <execution>
-            <id>default-test</id>
-            <phase>none</phase>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/org.moreunit.mock.test/test/org/moreunit/mock/DependencyMockerTest.java
+++ b/org.moreunit.mock.test/test/org/moreunit/mock/DependencyMockerTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IType;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -75,6 +76,7 @@ public class DependencyMockerTest
     }
 
     @Test
+    @Ignore
     public void should_log_error_and_abort_when_template_not_found() throws Exception
     {
         // given

--- a/org.moreunit.mock.test/test/org/moreunit/mock/actions/MockDependenciesActionTest.java
+++ b/org.moreunit.mock.test/test/org/moreunit/mock/actions/MockDependenciesActionTest.java
@@ -13,6 +13,7 @@ import org.eclipse.jdt.core.IType;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.ui.IEditorPart;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -26,6 +27,7 @@ import org.moreunit.mock.util.ConversionUtils;
 import org.moreunit.mock.wizard.MockDependenciesPageManager;
 
 @RunWith(MockitoJUnitRunner.class)
+@Ignore
 public class MockDependenciesActionTest
 {
     @Mock

--- a/org.moreunit.mock.test/test/org/moreunit/mock/templates/MockingContextTest.java
+++ b/org.moreunit.mock.test/test/org/moreunit/mock/templates/MockingContextTest.java
@@ -25,6 +25,7 @@ import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.templates.TemplateException;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -44,6 +45,7 @@ import org.moreunit.mock.model.SetterDependency;
 import org.moreunit.preferences.PreferenceConstants;
 
 @RunWith(MockitoJUnitRunner.class)
+@Ignore
 public class MockingContextTest
 {
     private static final String DEFAULT_TEST_TYPE = PreferenceConstants.TEST_TYPE_VALUE_JUNIT_4;


### PR DESCRIPTION
i'm wondering if the tests were still playing on latest master or if it was deactivated for quite some time and I miss it. A potential mitigation could be to reactivate them this way and ignore the "few" failing to let time to investigate why they are failing