### PR TITLE
explicitly set project encoding

### DIFF
--- a/org.moreunit.build/.settings/org.eclipse.core.resources.prefs
+++ b/org.moreunit.build/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.moreunit.core.test/.settings/org.eclipse.core.resources.prefs
+++ b/org.moreunit.core.test/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.moreunit.core/.settings/org.eclipse.core.resources.prefs
+++ b/org.moreunit.core/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.moreunit.extension/.settings/org.eclipse.core.resources.prefs
+++ b/org.moreunit.extension/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.moreunit.feature/.settings/org.eclipse.core.resources.prefs
+++ b/org.moreunit.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.moreunit.light.feature/.settings/org.eclipse.core.resources.prefs
+++ b/org.moreunit.light.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.moreunit.mock.feature/.settings/org.eclipse.core.resources.prefs
+++ b/org.moreunit.mock.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.moreunit.mock.it/.settings/org.eclipse.core.resources.prefs
+++ b/org.moreunit.mock.it/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.moreunit.mock.test/.settings/org.eclipse.core.resources.prefs
+++ b/org.moreunit.mock.test/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.moreunit.swtbot.test/.settings/org.eclipse.core.resources.prefs
+++ b/org.moreunit.swtbot.test/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.moreunit.test.dependencies/.settings/org.eclipse.core.resources.prefs
+++ b/org.moreunit.test.dependencies/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.moreunit.test/.settings/org.eclipse.core.resources.prefs
+++ b/org.moreunit.test/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/org.moreunit.updatesite/.settings/org.eclipse.core.resources.prefs
+++ b/org.moreunit.updatesite/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8


### PR DESCRIPTION
Since a while Eclipse wants to have us select an explicit encoding to avoid depending on the default encoding of the operating system via the workspace preferences (which is or was different on Windows and Linux).

Checking this in avoids a warning on recent IDE versions and ensures that projects are using UTF-8 encoding both when being edited and when compiled (where the maven encoding properties are relevant).