### PR TITLE
fix #169: use correct parent shell in modal dialogs

### DIFF
--- a/org.moreunit.plugin/src/org/moreunit/properties/AddUnitSourceFolderWizard.java
+++ b/org.moreunit.plugin/src/org/moreunit/properties/AddUnitSourceFolderWizard.java
@@ -8,7 +8,7 @@ import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.jface.wizard.WizardDialog;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.ui.PlatformUI;
+import org.eclipse.swt.widgets.Shell;
 import org.moreunit.elements.SourceFolderMapping;
 
 /**
@@ -54,9 +54,9 @@ public class AddUnitSourceFolderWizard extends Wizard
         super.createPageControls(pageContainer);
     }
 
-    public void open()
+    public void open(Shell parentShell)
     {
-        WizardDialog dialog = new WizardDialog(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), this);
+        WizardDialog dialog = new WizardDialog(parentShell, this);
         dialog.open();
     }
 

--- a/org.moreunit.plugin/src/org/moreunit/properties/UnitSourceFolderBlock.java
+++ b/org.moreunit.plugin/src/org/moreunit/properties/UnitSourceFolderBlock.java
@@ -19,7 +19,6 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
-import org.eclipse.ui.PlatformUI;
 import org.moreunit.SourceFolderContext;
 import org.moreunit.elements.SourceFolderMapping;
 import org.moreunit.preferences.Preferences;
@@ -164,7 +163,7 @@ public class UnitSourceFolderBlock implements ISelectionChangedListener
 
     private void addButtonClicked()
     {
-        new AddUnitSourceFolderWizard(javaProject, this).open();
+        new AddUnitSourceFolderWizard(javaProject, this).open(propertyPage.getShell());
     }
 
     private void removeButtonClicked()
@@ -182,7 +181,7 @@ public class UnitSourceFolderBlock implements ISelectionChangedListener
     private void mappingButtonClicked()
     {
         TreeSelection selection = (TreeSelection) sourceFolderTree.getSelection();
-        (new SourceFolderMappingDialog(this, PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(), (SourceFolderMapping) selection.getFirstElement())).open();
+        (new SourceFolderMappingDialog(this, propertyPage.getShell(), (SourceFolderMapping) selection.getFirstElement())).open();
     }
 
     public void handlePerformFinishFromAddUnitSourceFolderWizard(List<SourceFolderMapping> mappingsToAdd)


### PR DESCRIPTION
Using the workbench active window shell is wrong, if another modal dialog is in front of the workbench window. Generally speaking, the shell of a new dialog should always be the currently active window.