### PR TITLE
avoid SWT resource leak

### DIFF
--- a/org.moreunit.plugin/src/org/moreunit/ui/MissingTestmethodViewPart.java
+++ b/org.moreunit.plugin/src/org/moreunit/ui/MissingTestmethodViewPart.java
@@ -9,7 +9,6 @@ import org.eclipse.ui.part.IPage;
 import org.eclipse.ui.part.MessagePage;
 import org.eclipse.ui.part.PageBook;
 import org.eclipse.ui.part.PageBookView;
-import org.moreunit.MoreUnitPlugin;
 import org.moreunit.elements.EditorPartFacade;
 import org.moreunit.util.PluginTools;
 
@@ -20,13 +19,6 @@ public class MissingTestmethodViewPart extends PageBookView
 {
 
     MethodPage activePage;
-
-    public MissingTestmethodViewPart()
-    {
-        super();
-
-        setTitleImage(MoreUnitPlugin.getImageDescriptor("icons/moreunitLogo.gif").createImage());
-    }
 
     @Override
     public void createPartControl(Composite parent)


### PR DESCRIPTION
Whenever an image is created, it must be disposed, too. Here it's not even necessary, because the view has an image.

```
java.lang.Error: SWT Resource was not properly disposed
	at org.eclipse.swt.graphics.Resource.initNonDisposeTracking(Resource.java:172)
	at org.eclipse.swt.graphics.Resource.<init>(Resource.java:120)
	at org.eclipse.swt.graphics.Image.<init>(Image.java:668)
	at org.eclipse.jface.resource.URLImageDescriptor.createImage(URLImageDescriptor.java:275)
	at org.eclipse.jface.resource.ImageDescriptor.createImage(ImageDescriptor.java:290)
	at org.eclipse.jface.resource.ImageDescriptor.createImage(ImageDescriptor.java:268)
	at org.moreunit.ui.MissingTestmethodViewPart.<init>(MissingTestmethodViewPart.java:28)
```