### PR TITLE
ClassCastException in property page

### DIFF
--- a/org.moreunit.plugin/src/org/moreunit/properties/MoreUnitPropertyPage.java
+++ b/org.moreunit.plugin/src/org/moreunit/properties/MoreUnitPropertyPage.java
@@ -3,6 +3,8 @@ package org.moreunit.properties;
 import java.io.IOException;
 
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.Adapters;
+import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
 import org.eclipse.jface.preference.IPreferenceStore;
@@ -126,11 +128,15 @@ public class MoreUnitPropertyPage extends PropertyPage
 
     private IJavaProject getJavaProject()
     {
-        if(getElement() instanceof IJavaProject)
+        IAdaptable selection = getElement();
+        if(selection instanceof IJavaProject)
         {
-            return (IJavaProject) getElement();
+            return (IJavaProject) selection;
         }
-        return JavaCore.create((IProject) getElement());
+        // when files are selected, they need to be adapted to their project
+        // first (see enabledWhen clause of plugin.xml)
+        IProject project = Adapters.adapt(selection, IProject.class);
+        return JavaCore.create(project);
     }
 
     private void handleCheckboxSelectionChanged()


### PR DESCRIPTION
When a Java project sub element is selected, the property page registration in plugin.xml wants to show the properties of the containing project, but the Java code doesn't adapt such sub elements to their project.

```
java.lang.ClassCastException: class
org.eclipse.jdt.internal.core.CompilationUnit cannot be cast to class org.eclipse.core.resources.IProject
(org.eclipse.jdt.internal.core.CompilationUnit is in unnamed module of loader org.eclipse.osgi.internal.loader.EquinoxClassLoader @1b446f3e; org.eclipse.core.resources.IProject is in unnamed module of loader org.eclipse.osgi.internal.loader.EquinoxClassLoader @2e94e7e4)
	at org.moreunit.properties.MoreUnitPropertyPage.getJavaProject(MoreUnitPropertyPage.java:133)
```