### PR TITLE
Allow opening Java editor from missing tests view

### DIFF
--- a/org.moreunit.plugin/META-INF/MANIFEST.MF
+++ b/org.moreunit.plugin/META-INF/MANIFEST.MF
@@ -16,7 +16,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ltk.core.refactoring,
  org.eclipse.ui,
  org.eclipse.ui.workbench.texteditor,
- org.moreunit.core
+ org.moreunit.core,
+ org.eclipse.ui.ide
 xxEclipse-AutoStart: true
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .

--- a/org.moreunit.plugin/src/org/moreunit/ui/MissingTestmethodViewPart.java
+++ b/org.moreunit.plugin/src/org/moreunit/ui/MissingTestmethodViewPart.java
@@ -1,9 +1,31 @@
 package org.moreunit.ui;
 
+import java.util.Arrays;
+
+import org.eclipse.core.resources.IContainer;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.jdt.core.IType;
+import org.eclipse.jface.window.Window;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.graphics.Color;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Link;
+import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.ide.IDE;
+import org.eclipse.ui.internal.ide.dialogs.OpenResourceDialog;
 import org.eclipse.ui.part.EditorPart;
 import org.eclipse.ui.part.IPage;
 import org.eclipse.ui.part.MessagePage;
@@ -34,10 +56,9 @@ public class MissingTestmethodViewPart extends PageBookView
     @Override
     protected IPage createDefaultPage(PageBook book)
     {
-        MessagePage page = new MessagePage();
+        MessagePage page = new EmptyPage();
         initPage(page);
         page.createControl(book);
-        page.setMessage("kein Outline");
         return page;
     }
 
@@ -155,4 +176,90 @@ public class MissingTestmethodViewPart extends PageBookView
             }
         }
     }
+
+    static class EmptyPage extends MessagePage {
+        private Composite fControl;
+
+        @Override
+        public void createControl(Composite parent) {
+            Color background= parent.getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND);
+
+            Composite composite= new Composite(parent, SWT.NONE);
+            composite.setLayout(new GridLayout(1, false));
+
+            composite.setBackground(background);
+
+            Link link= new Link(composite, SWT.NONE);
+            link.setText("No Java editor opened. Open a <a>Java file</a>...");
+            link.setLayoutData(new GridData(SWT.BEGINNING, SWT.CENTER, true, false));
+            link.setBackground(background);
+            link.addSelectionListener(new SelectionAdapter() {
+                @Override
+                public void widgetSelected(SelectionEvent e) {
+                    openResource();
+                }
+            });
+
+            fControl= composite;
+        }
+
+        protected void openResource()
+        {
+            final IWorkbenchWindow window = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+            if(window == null)
+            {
+                return;
+            }
+            final Shell parent = window.getShell();
+            final IContainer input = ResourcesPlugin.getWorkspace().getRoot();
+
+            final OpenResourceDialog dialog = new OpenResourceDialog(parent, input, IResource.FILE);
+            dialog.setInitialPattern("*.java");
+            if(dialog.open() != Window.OK)
+            {
+                return;
+            }
+
+            Object[] result = dialog.getResult();
+            if(result == null)
+            {
+                return;
+            }
+            var files = Arrays.stream(result).filter(IFile.class::isInstance).map(IFile.class::cast).toList();
+            if(files.isEmpty())
+            {
+                return;
+            }
+            final IWorkbenchPage page = window.getActivePage();
+            if(page == null)
+            {
+                return;
+            }
+
+            try
+            {
+                for (IFile iFile : files)
+                {
+                    IDE.openEditor(page, iFile, true);
+                }
+            }
+            catch (final PartInitException e)
+            {
+                // ignore
+            }
+        }
+
+        @Override
+        public Control getControl() {
+            return fControl;
+        }
+
+        @Override
+        public void setFocus() {
+            if (fControl != null)
+                fControl.setFocus();
+        }
+
+    }
+
 }


### PR DESCRIPTION
Changes the static message in the empty "missing tests" view to a hyperlink to open Java files, similar like an empty search results view behaves.

![grafik](https://github.com/MoreUnit/MoreUnit-Eclipse/assets/406876/ff5c300a-74fc-4939-9963-91c2de6d7474)

