### PR TITLE
Sort missing test methods alphabetically for easier reading

### DIFF
--- a/org.moreunit.plugin/src/org/moreunit/ui/MethodPage.java
+++ b/org.moreunit.plugin/src/org/moreunit/ui/MethodPage.java
@@ -14,6 +14,7 @@ import org.eclipse.jface.viewers.DoubleClickEvent;
 import org.eclipse.jface.viewers.IDoubleClickListener;
 import org.eclipse.jface.viewers.ITreeSelection;
 import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.jface.viewers.ViewerComparator;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.ui.PlatformUI;
@@ -59,6 +60,7 @@ public class MethodPage extends Page implements IElementChangedListener, IDouble
         this.treeViewer.setLabelProvider(new JavaElementLabelProvider());
         this.treeViewer.setInput(this);
         this.treeViewer.addDoubleClickListener(this);
+        treeViewer.setComparator(new ViewerComparator());
 
         createToolbar();
     }


### PR DESCRIPTION
Even better would be using the sort order of the Java outline view, but that might be a bit more complicated.

Looks like this: 
![grafik](https://github.com/MoreUnit/MoreUnit-Eclipse/assets/406876/85325339-ab8b-469b-8125-630aba4df691)
