### PR TITLE
Exception in missing tests view

### DIFF
--- a/org.moreunit.plugin/src/org/moreunit/elements/MissingClassTreeContentProvider.java
+++ b/org.moreunit.plugin/src/org/moreunit/elements/MissingClassTreeContentProvider.java
@@ -16,10 +16,10 @@ import org.moreunit.util.PluginTools;
 
 public class MissingClassTreeContentProvider implements ITreeContentProvider
 {
-    
+
     public MissingClassTreeContentProvider()
     {
-        
+
     }
 
     public Object[] getChildren(Object arg0)
@@ -57,9 +57,14 @@ public class MissingClassTreeContentProvider implements ITreeContentProvider
                             ICompilationUnit[] compilationUnits = ((IPackageFragment) javaPackage).getCompilationUnits();
                             for (ICompilationUnit compilationUnit : compilationUnits)
                             {
-                                ClassTypeFacade classTypeFacade = new ClassTypeFacade(compilationUnit);
-                                if(!TypeFacade.isTestCase(compilationUnit) && !classTypeFacade.hasTestCase())
-                                    elements.add(compilationUnit);
+                                if(compilationUnit.findPrimaryType() != null)
+                                {
+                                    ClassTypeFacade classTypeFacade = new ClassTypeFacade(compilationUnit);
+                                    if(! TypeFacade.isTestCase(compilationUnit) && ! classTypeFacade.hasTestCase())
+                                    {
+                                        elements.add(compilationUnit);
+                                    }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
The content provider doesn't deal with Java files not containing a type, like package-info.java. To avoid the exception, check for a primary type in the compilation unit.