### PR TITLE
Let dependabot upgrade GitHub actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,14 @@
 version: 2
 updates:
 - package-ecosystem: maven
-  directory: "/org.moreunit.build"
+  directory: /
   schedule:
     interval: daily
   open-pull-requests-limit: 10
   reviewers:
   - apupier
+
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily


### PR DESCRIPTION
Also let it check all Maven POMs, not just the one of the aggregator project.

In a next step we should then use pinned actions (that is not specifying their version, but their git hash).

The upgraded actions should then remove some build log warnings specifically about actions. See the bottom of https://github.com/MoreUnit/MoreUnit-Eclipse/actions/runs/7165952960 for some examples.