### PR TITLE
Change default preferences to JUnit 5 and no test method prefix

### DIFF
--- a/org.moreunit.plugin/src/org/moreunit/preferences/PreferenceConstants.java
+++ b/org.moreunit.plugin/src/org/moreunit/preferences/PreferenceConstants.java
@@ -38,7 +38,7 @@ public interface PreferenceConstants
     boolean DEFAULT_SWITCH_TO_MATCHING_METHOD = true;
     String DEFAULT_TEST_PACKAGE_PREFIX = "";
     String DEFAULT_TEST_PACKAGE_SUFFIX = "";
-    String DEFAULT_TEST_TYPE = PreferenceConstants.TEST_TYPE_VALUE_JUNIT_4;
+    String DEFAULT_TEST_TYPE = PreferenceConstants.TEST_TYPE_VALUE_JUNIT_5;
     String DEFAULT_TEST_SUPERCLASS = "";
     boolean DEFAULT_EXTENDED_TEST_METHOD_SEARCH = true;
     boolean DEFAULT_ENABLE_TEST_METHOD_SEARCH_BY_NAME = true;

--- a/org.moreunit.plugin/src/org/moreunit/preferences/Preferences.java
+++ b/org.moreunit.plugin/src/org/moreunit/preferences/Preferences.java
@@ -73,7 +73,7 @@ public class Preferences
         store.setDefault(PreferenceConstants.SWITCH_TO_MATCHING_METHOD, PreferenceConstants.DEFAULT_SWITCH_TO_MATCHING_METHOD);
         store.setDefault(PreferenceConstants.TEST_PACKAGE_PREFIX, PreferenceConstants.DEFAULT_TEST_PACKAGE_PREFIX);
         store.setDefault(PreferenceConstants.TEST_SUPERCLASS, PreferenceConstants.DEFAULT_TEST_SUPERCLASS);
-        store.setDefault(PreferenceConstants.TEST_METHOD_TYPE, PreferenceConstants.TEST_METHOD_TYPE_JUNIT3);
+        store.setDefault(PreferenceConstants.TEST_METHOD_TYPE, PreferenceConstants.TEST_METHOD_TYPE_NO_PREFIX);
         store.setDefault(PreferenceConstants.EXTENDED_TEST_METHOD_SEARCH, PreferenceConstants.DEFAULT_EXTENDED_TEST_METHOD_SEARCH);
         store.setDefault(PreferenceConstants.ENABLE_TEST_METHOD_SEARCH_BY_NAME, PreferenceConstants.DEFAULT_ENABLE_TEST_METHOD_SEARCH_BY_NAME);
         store.setDefault(PreferenceConstants.TEST_CLASS_NAME_TEMPLATE, PreferenceConstants.DEFAULT_TEST_CLASS_NAME_TEMPLATE);


### PR DESCRIPTION
We should use current and recommended default values. If people have older frameworks in use, they can enable the older versions and a prefix on their own.

![grafik](https://github.com/MoreUnit/MoreUnit-Eclipse/assets/406876/8d152f65-7e37-4dc2-9f1b-458de933a014)
