### PR TITLE
Avoid exception in MethodPage

### DIFF
--- a/org.moreunit.plugin/src/org/moreunit/ui/MethodPage.java
+++ b/org.moreunit.plugin/src/org/moreunit/ui/MethodPage.java
@@ -184,7 +184,10 @@ public class MethodPage extends Page implements IElementChangedListener, IDouble
 
     public void updateUI()
     {
-        this.treeViewer.refresh();
+        if(! treeViewer.getControl().isDisposed())
+        {
+            treeViewer.refresh();
+        }
     }
 
     public void elementChanged(ElementChangedEvent event)


### PR DESCRIPTION
Asynchronously executed UI update methods always must check whether the widget is already disposed.

org.eclipse.swt.SWTException: Widget is disposed
	at org.eclipse.swt.SWT.error(SWT.java:4918)
	at org.eclipse.swt.SWT.error(SWT.java:4833)
	at org.eclipse.swt.SWT.error(SWT.java:4804)
	at org.eclipse.swt.widgets.Widget.error(Widget.java:450)
	at org.eclipse.swt.widgets.Widget.checkWidget(Widget.java:369)
	at org.eclipse.swt.widgets.Tree.setRedraw(Tree.java:4955)
	at org.eclipse.jface.viewers.StructuredViewer.refresh(StructuredViewer.java:1419)
	at org.moreunit.ui.MethodPage.updateUI(MethodPage.java:187)
	at org.moreunit.ui.MethodPage$4.run(MethodPage.java:210)
	at org.eclipse.swt.widgets.RunnableLock.run(RunnableLock.java:40)
	at org.eclipse.swt.widgets.Synchronizer.runAsyncMessages(Synchronizer.java:132)
	at org.eclipse.swt.widgets.Display.runAsyncMessages(Display.java:4046)
	at org.eclipse.swt.widgets.Display.readAndDispatch(Display.java:3662)