### PR TITLE
Remove artificial indentation from code mining

### DIFF
--- a/org.moreunit.plugin/src/org/moreunit/codemining/JumpCodeMining.java
+++ b/org.moreunit.plugin/src/org/moreunit/codemining/JumpCodeMining.java
@@ -75,7 +75,7 @@ public class JumpCodeMining extends LineEndCodeMining
                 IMember memberToJump = typeFacade.getOneCorrespondingMember(request);
                 if(memberToJump != null)
                 {
-                    setLabel(" Jump to " + testOrTested + " class");
+                    setLabel("Jump to " + testOrTested + " class");
                 }
                 else
                 {
@@ -108,7 +108,7 @@ public class JumpCodeMining extends LineEndCodeMining
                 }
                 if(jumpable)
                 {
-                    setLabel(" Jump to " + testOrTested + " method");
+                    setLabel("Jump to " + testOrTested + " method");
                 }
                 else
                 {


### PR DESCRIPTION
Don't try to add custom indentation to the label by prefixing it with whitespace. That leads to the confusing situation that _some_ of the whitespace between the class declaration and the code mining text is clickable and some is not, as in the screenshot:
![grafik](https://github.com/MoreUnit/MoreUnit-Eclipse/assets/406876/ab8b2e6e-7e4c-41e3-bc4e-c053c7510af6)
