### PR TITLE
Avoid product not found warning in SWTBot test

### DIFF
--- a/org.moreunit.swtbot.test/META-INF/MANIFEST.MF
+++ b/org.moreunit.swtbot.test/META-INF/MANIFEST.MF
@@ -13,6 +13,7 @@ Require-Bundle: org.eclipse.swtbot.go,
  org.moreunit,
  org.eclipse.ltk.ui.refactoring,
  org.eclipse.jdt.ui,
- org.eclipse.ui.ide
+ org.eclipse.ui.ide,
+ org.eclipse.platform;bundle-version="4.25.0"
 Import-Package: org.eclipse.jdt.ui
 Automatic-Module-Name: org.moreunit.swtbot.test


### PR DESCRIPTION
```
!ENTRY org.eclipse.equinox.app 0 0 2023-12-25 20:55:26.713 !MESSAGE Product org.eclipse.platform.ide could not be found.
```

When running surefire tests in Tycho Surefire, only the dependencies of the test bundle will be loaded, not the complete target platform. If we have implicit dependencies (like to the bundle containing the eclipse product we want to launch), then the plugin containing the product declaration must explicitly be added to the target platform configuration during execution or as bundle dependency to the test plugin classpath.

Example of the warning from a recent build: https://github.com/MoreUnit/MoreUnit-Eclipse/actions/runs/7314698114/job/19927583966#step:8:71714