### PR TITLE
Improve preference pages

### DIFF
--- a/org.moreunit.mock/src/org/moreunit/mock/preferences/MainPropertyPage.java
+++ b/org.moreunit.mock/src/org/moreunit/mock/preferences/MainPropertyPage.java
@@ -1,5 +1,7 @@
 package org.moreunit.mock.preferences;
 
+import static org.moreunit.mock.config.MockModule.$;
+
 import org.eclipse.core.resources.IProject;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.JavaCore;
@@ -13,8 +15,6 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.ui.dialogs.PropertyPage;
 import org.moreunit.core.log.Logger;
-
-import static org.moreunit.mock.config.MockModule.$;
 
 public class MainPropertyPage extends PropertyPage
 {
@@ -34,6 +34,7 @@ public class MainPropertyPage extends PropertyPage
         this.preferences = preferences;
         this.templateStyleSelector = templateStyleSelector;
         this.logger = logger;
+        noDefaultButton();
     }
 
     @Override

--- a/org.moreunit.plugin/src/org/moreunit/properties/AddUnitSourceFolderWizard.java
+++ b/org.moreunit.plugin/src/org/moreunit/properties/AddUnitSourceFolderWizard.java
@@ -7,7 +7,6 @@ import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jface.wizard.Wizard;
 import org.eclipse.jface.wizard.WizardDialog;
-import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Shell;
 import org.moreunit.elements.SourceFolderMapping;
 
@@ -24,11 +23,12 @@ public class AddUnitSourceFolderWizard extends Wizard
 
     private UnitSourceFolderBlock unitSourceFolderBlock;
 
-
     public AddUnitSourceFolderWizard(IJavaProject javaProject, UnitSourceFolderBlock unitSourceFolderBlock)
     {
         this.javaProject = javaProject;
         this.unitSourceFolderBlock = unitSourceFolderBlock;
+        setWindowTitle("MoreUnit test source folders");
+        setHelpAvailable(false);
     }
 
     @Override
@@ -46,12 +46,10 @@ public class AddUnitSourceFolderWizard extends Wizard
     }
 
     @Override
-    public void createPageControls(Composite pageContainer)
+    public void addPages()
     {
-        setWindowTitle("MoreUnit test source folders");
         page = new AddUnitSourceFolderWizardPage();
         addPage(page);
-        super.createPageControls(pageContainer);
     }
 
     public void open(Shell parentShell)

--- a/org.moreunit.plugin/src/org/moreunit/properties/AddUnitSourceFolderWizardPage.java
+++ b/org.moreunit.plugin/src/org/moreunit/properties/AddUnitSourceFolderWizardPage.java
@@ -29,6 +29,7 @@ public class AddUnitSourceFolderWizardPage extends WizardPage implements ICheckS
         super("Add Unit Source Folder");
         setTitle("Add Unit Source Folder");
         setDescription("Please select source folders to add");
+        setPageComplete(false);
     }
 
     public void createControl(Composite parent)
@@ -83,6 +84,8 @@ public class AddUnitSourceFolderWizardPage extends WizardPage implements ICheckS
             else if(! isChecked && ! isNoSourceFolderInProjectSelected(javaProject))
                 checkboxTreeViewer.setGrayChecked(javaProject, true);
         }
+
+        setPageComplete(checkboxTreeViewer.getCheckedElements().length > 0);
     }
 
     private boolean areAllSourceFolderInProjectSelected(Object javaProjectElement)

--- a/org.moreunit.plugin/src/org/moreunit/properties/MoreUnitPropertyPage.java
+++ b/org.moreunit.plugin/src/org/moreunit/properties/MoreUnitPropertyPage.java
@@ -36,6 +36,11 @@ public class MoreUnitPropertyPage extends PropertyPage
     private UnitSourceFolderBlock firstTabUnitSourceFolder;
     private OtherMoreunitPropertiesBlock secondTabOtherProperties;
 
+    public MoreUnitPropertyPage()
+    {
+        noDefaultButton();
+    }
+
     @Override
     protected Control createContents(Composite parent)
     {

--- a/org.moreunit.plugin/src/org/moreunit/properties/UnitSourceFolderBlock.java
+++ b/org.moreunit.plugin/src/org/moreunit/properties/UnitSourceFolderBlock.java
@@ -181,7 +181,7 @@ public class UnitSourceFolderBlock implements ISelectionChangedListener
     private void mappingButtonClicked()
     {
         TreeSelection selection = (TreeSelection) sourceFolderTree.getSelection();
-        (new SourceFolderMappingDialog(this, propertyPage.getShell(), (SourceFolderMapping) selection.getFirstElement())).open();
+        SourceFolderMappingDialog.open(this, propertyPage.getShell(), (SourceFolderMapping) selection.getFirstElement());
     }
 
     public void handlePerformFinishFromAddUnitSourceFolderWizard(List<SourceFolderMapping> mappingsToAdd)

--- a/org.moreunit.plugin/src/org/moreunit/properties/WorkspaceSourceFolderContentProvider.java
+++ b/org.moreunit.plugin/src/org/moreunit/properties/WorkspaceSourceFolderContentProvider.java
@@ -1,6 +1,7 @@
 package org.moreunit.properties;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import org.eclipse.core.resources.IProject;
@@ -97,7 +98,7 @@ public class WorkspaceSourceFolderContentProvider implements ITreeContentProvide
             }
         }
 
-        return allJavaProjectsInWorkspace;
+        return allJavaProjectsInWorkspace.stream().sorted(Comparator.comparing((IJavaProject project) -> project.getElementName(), String.CASE_INSENSITIVE_ORDER)).toList();
     }
 
     /**


### PR DESCRIPTION
* disable help button in custom dialogs/wizards
* disable "restore default" buttons where resetting preferences to defaults is not implemented
* disable finish button in "add source" wizard if selection is empty
* replace custom "remap" dialog by standard JFace selection dialog
* fix sort order of projects

The remapping dialog looks like this now: 
![grafik](https://github.com/MoreUnit/MoreUnit-Eclipse/assets/406876/0f2f39cc-ddaa-4d07-9209-b535ad3ce49b)
