### PR TITLE
Use styled label provider for selection popup

### DIFF
--- a/org.moreunit.plugin/src/org/moreunit/codemining/JumpCodeMining.java
+++ b/org.moreunit.plugin/src/org/moreunit/codemining/JumpCodeMining.java
@@ -121,10 +121,12 @@ public class JumpCodeMining extends LineEndCodeMining
 
             TypeFacade typeFacade = TypeFacade.createFacade(((IMember) element).getCompilationUnit());
 
+            String testOrTested = typeFacade instanceof TestCaseTypeFacade ? "tested" : "test";
             CorrespondingMemberRequest request = newCorrespondingMemberRequest() //
                     .withExpectedResultType(MemberType.TYPE_OR_METHOD) //
                     .withCurrentMethod(element instanceof IMethod method ? method : null) //
                     .methodSearchMode(searchMode) //
+                    .promptText("Jump to " + testOrTested + " class...")
                     .build();
 
             IMember memberToJump = typeFacade.getOneCorrespondingMember(request);

--- a/org.moreunit.plugin/src/org/moreunit/elements/CorrespondingMemberRequest.java
+++ b/org.moreunit.plugin/src/org/moreunit/elements/CorrespondingMemberRequest.java
@@ -61,17 +61,25 @@ public class CorrespondingMemberRequest
 
         /**
          * Will propose the creation of a type if no correspondence is found.
-         * 
+         *
          * @param promptText the prompt text to display in the dialog asking the
          *            user to choose for a member
          */
         public Builder createClassIfNoResult(String promptText)
         {
             this.createClassIfNoResult = true;
+            return promptText(promptText);
+        }
+
+        /**
+         * @param promptText the prompt text to display in the dialog asking the
+         *            user to choose for a member
+         */
+        public Builder promptText(String promptText)
+        {
             this.promptText = promptText;
             return this;
         }
-
         /**
          * How to search for corresponding methods (by call or/and by method
          * name).


### PR DESCRIPTION
Show the package of types as decorated text for better readability. Also add overlays to the images created by the label provider.

Add a header label for selection dialogs created from the code mining.

before:
![grafik](https://github.com/MoreUnit/MoreUnit-Eclipse/assets/406876/81398d21-1ff9-4089-ad39-51c801053ab7)

after:
![grafik](https://github.com/MoreUnit/MoreUnit-Eclipse/assets/406876/387d7a99-c969-4f14-bf07-17317c39577f)
