### PR TITLE
Add toggle for "Jump to test method" code mining link

### DIFF
--- a/org.moreunit.plugin/src/org/moreunit/codemining/MoreUnitCodeMiningProvider.java
+++ b/org.moreunit.plugin/src/org/moreunit/codemining/MoreUnitCodeMiningProvider.java
@@ -92,7 +92,7 @@ public class MoreUnitCodeMiningProvider extends AbstractCodeMiningProvider
                     addMining = true;
                 }
             }
-            else if(element instanceof IMethod)
+            else if(element instanceof IMethod && preferences.shouldEnableJumpToMethodCodeMining(unit.getJavaProject()))
             {
                 addMining = true;
             }

--- a/org.moreunit.plugin/src/org/moreunit/preferences/PreferenceConstants.java
+++ b/org.moreunit.plugin/src/org/moreunit/preferences/PreferenceConstants.java
@@ -26,6 +26,7 @@ public interface PreferenceConstants
     String TEST_CLASS_NAME_TEMPLATE = "org.moreunit.testClassNameTemplate";
     String GENERATE_COMMENTS_FOR_TEST_METHOD = "org.moreunit.generateCommentsForTestMethod";
     String ENABLE_MOREUNIT_CODE_MINING = "org.moreunit.enableMoreUnitCodeMining";
+    String ENABLE_JUMP_TO_METHOD_CODE_MINING = "org.moreunit.enableJumpToMethodCodeMining";
 
     String TEST_TYPE = "org.moreunit.test_type";
     String TEST_TYPE_VALUE_JUNIT_3 = "junit3";
@@ -47,6 +48,7 @@ public interface PreferenceConstants
     String DEFAULT_TEST_METHOD_DEFAULT_CONTENT = "throw new RuntimeException(\"not yet implemented\");";
     String DEFAULT_TEST_ANNOTATION_MODE = "OFF";
     boolean DEFAULT_ENABLE_MOREUNIT_CODEMINING = true;
+    boolean DEFAULT_ENABLE_JUMP_TO_METHOD_CODE_MINING = true;
 
     String TEXT_GENERAL_SETTINGS = "General settings for your unit tests (they can then be refined for each project):";
     String TEXT_TEST_SUPERCLASS = "Test superclass:";
@@ -65,6 +67,7 @@ public interface PreferenceConstants
     String TEXT_ENABLE_TEST_METHOD_SEARCH_BY_NAME = "Enable test method search \"by name\"";
     String TEXT_GENERATE_COMMENTS_FOR_TEST_METHOD = "Generate comments for test methods";
     String TEXT_ENABLE_MOREUNIT_CODEMINING = "Enable MoreUnit Code Mining";
+    String TEXT_ENABLE_JUMP_TO_METHOD_CODE_MINING = "Enable \"Jump to method\" Code Mining (on the right side of the editor)";
     String TEXT_ANNOTATION_MODE = "Annotate tested methods";
     String TEST_ANNOTATION_MODE_DISABLED = "Disabled";
     String TEST_ANNOTATION_MODE_BY_NAME = "Search by method name";
@@ -78,6 +81,8 @@ public interface PreferenceConstants
     String TOOLTIP_EXTENDED_TEST_METHOD_SEARCH = "Enable this option if you want MoreUnit to propose jumping from a given method to any test method that calls it (and vice-versa).";
     String TOOLTIP_ENABLE_TEST_METHOD_SEARCH_BY_NAME = "Check this option if you want MoreUnit to blindly propose jumping from a given method to a test method with the same name, even though the test method does not call the method under test.";
     String TOOLTIP_TEST_ANNOTATION_EXTENDED_SEARCH = "This option will cause conflicts if other parts of Eclipse are searching for method method calls at the same time, which occurs often. Only activate if you know what you are doing.";
+    String TOOLTIP_ENABLE_MOREUNIT_CODEMINING = "Code Mining adds information and links directly in the editor.";
+    String TOOLTIP_ENABLE_JUMP_TO_METHOD_CODE_MINING = "Shows a \"Jump to test/tested method\" link at the end of method declarations.";
 
     String TEST_METHOD_TYPE = "org.moreunit.test_methodType";
     String TEST_METHOD_TYPE_JUNIT3 = "testMethodTypeJunit3";

--- a/org.moreunit.plugin/src/org/moreunit/preferences/Preferences.java
+++ b/org.moreunit.plugin/src/org/moreunit/preferences/Preferences.java
@@ -80,6 +80,7 @@ public class Preferences
         store.setDefault(PreferenceConstants.TEST_METHOD_DEFAULT_CONTENT, PreferenceConstants.DEFAULT_TEST_METHOD_DEFAULT_CONTENT);
         store.setDefault(PreferenceConstants.TEST_ANNOTATION_MODE, PreferenceConstants.DEFAULT_TEST_ANNOTATION_MODE);
         store.setDefault(PreferenceConstants.ENABLE_MOREUNIT_CODE_MINING, PreferenceConstants.DEFAULT_ENABLE_MOREUNIT_CODEMINING);
+        store.setDefault(PreferenceConstants.ENABLE_JUMP_TO_METHOD_CODE_MINING, PreferenceConstants.DEFAULT_ENABLE_JUMP_TO_METHOD_CODE_MINING);
         return store;
     }
 
@@ -491,6 +492,20 @@ public class Preferences
     public void setEnableMoreUnitCodeMining(IJavaProject javaProject, boolean enableMoreUnitCodeMining)
     {
         getProjectStore(javaProject).setValue(PreferenceConstants.ENABLE_MOREUNIT_CODE_MINING, enableMoreUnitCodeMining);
+    }
+
+    public boolean shouldEnableJumpToMethodCodeMining(IJavaProject javaProject)
+    {
+        if(storeToRead(javaProject).contains(PreferenceConstants.ENABLE_JUMP_TO_METHOD_CODE_MINING))
+        {
+            return storeToRead(javaProject).getBoolean(PreferenceConstants.ENABLE_JUMP_TO_METHOD_CODE_MINING);
+        }
+        return storeToRead(javaProject).getDefaultBoolean(PreferenceConstants.ENABLE_JUMP_TO_METHOD_CODE_MINING);
+    }
+
+    public void setEnableJumpToMethodCodeMining(IJavaProject javaProject, boolean enableJumpToMethodCodeMining)
+    {
+        getProjectStore(javaProject).setValue(PreferenceConstants.ENABLE_JUMP_TO_METHOD_CODE_MINING, enableJumpToMethodCodeMining);
     }
 
     public MethodSearchMode getMethodSearchMode(IJavaProject javaProject)

--- a/org.moreunit.plugin/src/org/moreunit/properties/OtherMoreunitPropertiesBlock.java
+++ b/org.moreunit.plugin/src/org/moreunit/properties/OtherMoreunitPropertiesBlock.java
@@ -43,6 +43,7 @@ public class OtherMoreunitPropertiesBlock implements SelectionListener
     private Text superClassTextField;
     private Button addCommentsToTestMethodCheckbox;
     private Button enableMoreUnitCodeMining;
+    private Button enableJumpToMethodCodeMiningCheckbox;
     private Button extendedSearchCheckbox;
     private Button enableSearchByNameCheckbox;
 
@@ -110,6 +111,7 @@ public class OtherMoreunitPropertiesBlock implements SelectionListener
         createTestAnnotationModeRadioButtons(parentWith2Cols);
         createAddCommentsToTestMethodsCheckbox(parentWith2Cols);
         createEnableMoreUnitCodeMiningCheckbox(parentWith2Cols);
+        createEnableJumpToMethodCodeMiningCheckbox(parentWith2Cols);
 
         checkStateOfMethodPrefixButton();
     }
@@ -329,8 +331,32 @@ public class OtherMoreunitPropertiesBlock implements SelectionListener
     {
         enableMoreUnitCodeMining = new Button(parent, SWT.CHECK);
         enableMoreUnitCodeMining.setText(PreferenceConstants.TEXT_ENABLE_MOREUNIT_CODEMINING);
+        enableMoreUnitCodeMining.setToolTipText(PreferenceConstants.TOOLTIP_ENABLE_MOREUNIT_CODEMINING);
         enableMoreUnitCodeMining.setLayoutData(layoutForOneLineControls);
         enableMoreUnitCodeMining.setSelection(preferences.shouldEnableMoreUnitCodeMining(javaProject));
+        enableMoreUnitCodeMining.addSelectionListener(new SelectionAdapter()
+        {
+            @Override
+            public void widgetSelected(SelectionEvent e)
+            {
+                enableJumpToMethodCodeMiningCheckbox.setEnabled(enableMoreUnitCodeMining.getSelection());
+            }
+        });
+    }
+
+    private void createEnableJumpToMethodCodeMiningCheckbox(Composite parent)
+    {
+        enableJumpToMethodCodeMiningCheckbox = new Button(parent, SWT.CHECK);
+        enableJumpToMethodCodeMiningCheckbox.setText(PreferenceConstants.TEXT_ENABLE_JUMP_TO_METHOD_CODE_MINING);
+        enableJumpToMethodCodeMiningCheckbox.setToolTipText(PreferenceConstants.TOOLTIP_ENABLE_JUMP_TO_METHOD_CODE_MINING);
+
+        GridData gridData = new GridData(GridData.HORIZONTAL_ALIGN_FILL);
+        gridData.horizontalSpan = 2;
+        gridData.horizontalIndent = 20;
+        enableJumpToMethodCodeMiningCheckbox.setLayoutData(gridData);
+
+        enableJumpToMethodCodeMiningCheckbox.setSelection(preferences.shouldEnableJumpToMethodCodeMining(javaProject));
+        enableJumpToMethodCodeMiningCheckbox.setEnabled(enableMoreUnitCodeMining.getSelection());
     }
 
     public void saveProperties()
@@ -359,6 +385,7 @@ public class OtherMoreunitPropertiesBlock implements SelectionListener
         preferences.setShouldUseTestMethodSearchByName(javaProject, enableSearchByNameCheckbox.getSelection());
         preferences.setGenerateCommentsForTestMethod(javaProject, addCommentsToTestMethodCheckbox.getSelection());
         preferences.setEnableMoreUnitCodeMining(javaProject, enableMoreUnitCodeMining.getSelection());
+        preferences.setEnableJumpToMethodCodeMining(javaProject, enableJumpToMethodCodeMiningCheckbox.getSelection());
 
         if(testAnnotationsByNameAndByCallButton.getSelection())
         {
@@ -452,6 +479,7 @@ public class OtherMoreunitPropertiesBlock implements SelectionListener
         extendedSearchCheckbox.setEnabled(enabled);
         enableSearchByNameCheckbox.setEnabled(enabled);
         addCommentsToTestMethodCheckbox.setEnabled(enabled);
+        enableJumpToMethodCodeMiningCheckbox.setEnabled(enabled && enableMoreUnitCodeMining.getSelection());
         testCaseNamePatternArea.setEnabled(enabled);
         testAnnotationsDisabledButton.setEnabled(enabled);
         testAnnotationsByNameButton.setEnabled(enabled);


### PR DESCRIPTION
This PR adds a new preference to MoreUnit that allows users to toggle the "Jump to test method" code mining link on and off. The setting is available both globally in Window -> Preferences -> MoreUnit -> Java and per-project in the MoreUnit property page.

Key changes:
- New preference constant and default value in `PreferenceConstants.java`.
- Accessor methods in `Preferences.java`.
- A new checkbox in `OtherMoreunitPropertiesBlock.java`, which is indented under the "Enable MoreUnit Code Mining" master switch and is only enabled when the master switch is active.
- Tooltips added to both Code Mining checkboxes for better clarity.
- `MoreUnitCodeMiningProvider.java` now checks the new preference before adding code mining to method declarations.

This addresses the issue where the link could be accidentally clicked or interfere with editor behavior.

---
*PR created automatically by Jules for task [2820775255716538622](https://jules.google.com/task/2820775255716538622) started by @RoiSoleil*