### PR TITLE
Add Codecov coverage badge and configuration

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,41 @@
+name: Coverage
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+permissions: write-all
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout 🛎
+        uses: actions/checkout@v4
+
+      - name: Set up Java ☕️
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+
+      - name: Setup Maven
+        uses: stCarolas/setup-maven@v4.5
+        with:
+          maven-version: 3.9.4
+
+      - name: Build with Coverage
+        run: mvn -file org.moreunit.build/pom.xml clean install -Pcoverage "-Dtarget.platform.classifier=eclipse-latest" --fail-at-end --batch-mode --strict-checksums --update-snapshots "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./org.moreunit.build/target/site/jacoco-aggregate/jacoco.xml
+          verbose: true
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MoreUnit For Eclipse
 
+[![codecov](https://codecov.io/gh/MoreUnit/MoreUnit-Eclipse/branch/master/graph/badge.svg)](https://codecov.io/gh/MoreUnit/MoreUnit-Eclipse)
+
 <img alt="MoreUnit Logo" src="https://moreunit.github.io/MoreUnit-Eclipse/img/logo.png" />
 
 MoreUnit is an Eclipse plugin that should assist you in writing more unit tests.

--- a/org.moreunit.build/pom.xml
+++ b/org.moreunit.build/pom.xml
@@ -34,7 +34,7 @@
     <tests.use.ui>false</tests.use.ui>
 
     <target.platform.classifier>eclipse-latest</target.platform.classifier>
-    <argLine></argLine>
+    <tycho.testArgLine></tycho.testArgLine>
 
   </properties>
   <build>
@@ -101,7 +101,7 @@
             <showEclipseLog>true</showEclipseLog>
             <skipAfterFailureCount>10</skipAfterFailureCount>
             <providerHint>junit4</providerHint>
-            <argLine>@{argLine} --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+            <argLine>${tycho.testArgLine} --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
           </configuration>
         </plugin>
         <plugin>
@@ -282,6 +282,9 @@
                 <goals>
                   <goal>prepare-agent</goal>
                 </goals>
+                <configuration>
+                  <propertyName>tycho.testArgLine</propertyName>
+                </configuration>
               </execution>
               <execution>
                 <id>merge-all</id>

--- a/org.moreunit.build/pom.xml
+++ b/org.moreunit.build/pom.xml
@@ -34,6 +34,7 @@
     <tests.use.ui>false</tests.use.ui>
 
     <target.platform.classifier>eclipse-latest</target.platform.classifier>
+    <argLine></argLine>
 
   </properties>
   <build>

--- a/org.moreunit.build/pom.xml
+++ b/org.moreunit.build/pom.xml
@@ -26,6 +26,7 @@
     <tycho-version>4.0.12</tycho-version>
     <exec-maven-version>3.5.0</exec-maven-version>
     <surefire-version>3.5.3</surefire-version>
+    <jacoco.version>0.8.14</jacoco.version>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -99,10 +100,13 @@
             <showEclipseLog>true</showEclipseLog>
             <skipAfterFailureCount>10</skipAfterFailureCount>
             <providerHint>junit4</providerHint>
-            <argLine>
-              --add-opens java.base/java.lang=ALL-UNNAMED
-            </argLine>
+            <argLine>@{argLine} --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>${jacoco.version}</version>
         </plugin>
         <plugin>
           <groupId>org.eclipse.tycho</groupId>
@@ -264,6 +268,56 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>coverage</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>prepare-agent</id>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>merge-all</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>merge</goal>
+                </goals>
+                <inherited>false</inherited>
+                <configuration>
+                  <fileSets>
+                    <fileSet>
+                      <directory>${project.basedir}/..</directory>
+                      <includes>
+                        <include>**/target/jacoco.exec</include>
+                      </includes>
+                    </fileSet>
+                  </fileSets>
+                  <destFile>${project.build.directory}/jacoco-all.exec</destFile>
+                </configuration>
+              </execution>
+              <execution>
+                <id>report-aggregate</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>report-aggregate</goal>
+                </goals>
+                <inherited>false</inherited>
+                <configuration>
+                  <dataFile>${project.build.directory}/jacoco-all.exec</dataFile>
+                  <outputDirectory>${project.build.directory}/site/jacoco-aggregate</outputDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <!-- makes test run in UI thread when under OSX -->
       <id>osx</id>


### PR DESCRIPTION
I have implemented a coverage badge for the MoreUnit-Eclipse project.

Key changes:
1.  **Maven Configuration**: Added `jacoco-maven-plugin` to the aggregator POM (`org.moreunit.build/pom.xml`) within a new `coverage` profile. This profile handles agent preparation for all modules and aggregation of results in the build directory.
2.  **GitHub Action**: Created `.github/workflows/coverage.yml` which triggers on pushes and pull requests to the `master` branch. It performs a full build with the `coverage` profile and uploads the aggregated Jacoco XML report to Codecov.
3.  **README**: Added a Codecov badge at the top of the `README.md` file to display the current coverage status.

Verified the Maven configuration by running a build with the `coverage` profile and confirming the generation of the `jacoco.xml` report.

---
*PR created automatically by Jules for task [303817167026478930](https://jules.google.com/task/303817167026478930) started by @RoiSoleil*