### PR TITLE
Support running tests from abstract classes by selecting concrete subclasses

### DIFF
--- a/org.moreunit.plugin/src/org/moreunit/handler/RunTestsActionExecutor.java
+++ b/org.moreunit.plugin/src/org/moreunit/handler/RunTestsActionExecutor.java
@@ -13,11 +13,16 @@ package org.moreunit.handler;
 
 import static org.moreunit.elements.CorrespondingMemberRequest.newCorrespondingMemberRequest;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
@@ -25,7 +30,10 @@ import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.internal.ui.javaeditor.EditorUtility;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IEditorPart;
 import org.moreunit.actions.RunTestAction;
 import org.moreunit.actions.RunTestFromCompilationUnitAction;
@@ -42,7 +50,12 @@ import org.moreunit.elements.TypeFacade;
 import org.moreunit.launch.TestLauncher;
 import org.moreunit.preferences.Preferences;
 import org.moreunit.preferences.Preferences.MethodSearchMode;
+import org.moreunit.ui.ChooseDialog;
+import org.moreunit.ui.MemberContentProvider;
+import org.moreunit.ui.TreeActionElement;
 import org.moreunit.util.FeatureDetector;
+import org.moreunit.util.MemberJumpHistory;
+import org.moreunit.util.SearchTools;
 
 /**
  * Executes the actions "Run test(s)" launched from the handlers:<br>
@@ -134,8 +147,54 @@ public class RunTestsActionExecutor
             {
                 testCases.add(selectedJavaType);
             }
-            return testCases;
+            return resolveAbstractTestCases(testCases);
         }, testCases -> runTests(testCases, launchMode));
+    }
+
+    private Collection<IType> resolveAbstractTestCases(Collection<IType> testCases)
+    {
+        Collection<IType> resolvedTestCases = new LinkedHashSet<>();
+        for (IType testCase : testCases)
+        {
+            resolvedTestCases.addAll(resolveAbstractTestCase(testCase));
+        }
+        return resolvedTestCases;
+    }
+
+    private Collection<IType> resolveAbstractTestCase(IType testCase)
+    {
+        try
+        {
+            if(! Flags.isAbstract(testCase.getFlags()))
+            {
+                return Collections.singleton(testCase);
+            }
+
+            Collection<IType> concreteSubclasses = SearchTools.findConcreteSubclasses(testCase);
+            if(concreteSubclasses.isEmpty())
+            {
+                return Collections.singleton(testCase);
+            }
+            if(concreteSubclasses.size() == 1)
+            {
+                return Collections.singleton(concreteSubclasses.iterator().next());
+            }
+
+            Collection<IType> choice = chooseSubclasses(testCase, concreteSubclasses);
+            if(choice != null && ! choice.isEmpty())
+            {
+                for (IType type : choice)
+                {
+                    MemberJumpHistory.getInstance().registerJump(testCase, type);
+                }
+                return choice;
+            }
+        }
+        catch (JavaModelException e)
+        {
+            // ignore and return original
+        }
+        return Collections.singleton(testCase);
     }
 
     private void saveIfNeeded(ICompilationUnit compilationUnit)
@@ -194,8 +253,137 @@ public class RunTestsActionExecutor
             {
                 testElements.add(getTestElementFromTestCase(methodFromEditor, selectedJavaType));
             }
-            return testElements;
+            return resolveAbstractTestElements(testElements);
         }, testElements -> runTests(testElements, launchMode));
+    }
+
+    private Collection<IMember> resolveAbstractTestElements(Collection<IMember> testElements)
+    {
+        Collection<IMember> resolvedTestElements = new LinkedHashSet<>();
+        for (IMember testElement : testElements)
+        {
+            resolvedTestElements.addAll(resolveAbstractTestElement(testElement));
+        }
+        return resolvedTestElements;
+    }
+
+    private Collection<IMember> resolveAbstractTestElement(IMember testElement)
+    {
+        IType type = testElement instanceof IType ? (IType) testElement : testElement.getDeclaringType();
+        try
+        {
+            if(! Flags.isAbstract(type.getFlags()))
+            {
+                return Collections.singleton(testElement);
+            }
+
+            Collection<IType> concreteSubclasses = SearchTools.findConcreteSubclasses(type);
+            if(concreteSubclasses.isEmpty())
+            {
+                return Collections.singleton(testElement);
+            }
+            if(concreteSubclasses.size() == 1)
+            {
+                return Collections.singleton(substituteType(testElement, concreteSubclasses.iterator().next()));
+            }
+
+            Collection<IType> chosenSubclasses = chooseSubclasses(type, concreteSubclasses);
+            if(chosenSubclasses != null && ! chosenSubclasses.isEmpty())
+            {
+                Collection<IMember> resolvedElements = new ArrayList<>();
+                for (IType chosenSubclass : chosenSubclasses)
+                {
+                    MemberJumpHistory.getInstance().registerJump(testElement, chosenSubclass);
+                    resolvedElements.add(substituteType(testElement, chosenSubclass));
+                }
+                return resolvedElements;
+            }
+        }
+        catch (JavaModelException e)
+        {
+            // ignore and return original
+        }
+        return Collections.singleton(testElement);
+    }
+
+    private IMember substituteType(IMember testElement, IType newType)
+    {
+        if(testElement instanceof IType)
+        {
+            return newType;
+        }
+        // It's a method. We return the method with the same name from the new type if it exists.
+        // If not, we still return the method from the abstract class, but the launcher should handle it.
+        // Actually, JDT's JUnit launcher handles methods from superclasses correctly if the target type is the subclass.
+        // But for clarity, let's see if we can find the method in the subclass.
+        IMethod method = (IMethod) testElement;
+        IMethod subclassMethod = newType.getMethod(method.getElementName(), method.getParameterTypes());
+        if(subclassMethod.exists())
+        {
+            return subclassMethod;
+        }
+        return method;
+    }
+
+    private Collection<IType> chooseSubclasses(IType abstractType, Collection<IType> concreteSubclasses)
+    {
+        IMember defaultSelection = MemberJumpHistory.getInstance().getLastCorrespondingJumpMember(abstractType);
+        if(! concreteSubclasses.contains(defaultSelection))
+        {
+            defaultSelection = null;
+        }
+
+        MemberContentProvider contentProvider = new MemberContentProvider(concreteSubclasses, (IType) defaultSelection);
+        contentProvider.withAction(new AllSubclassesAction(concreteSubclasses));
+
+        String promptText = "Choose concrete subclass for " + abstractType.getElementName();
+        return Display.getDefault().syncCall(() -> {
+            ChooseDialog<Object> dialog = new ChooseDialog<>(promptText, contentProvider);
+            Object choice = dialog.getChoice();
+            if(choice instanceof Collection)
+            {
+                return (Collection<IType>) choice;
+            }
+            if(choice instanceof IType)
+            {
+                return Collections.singleton((IType) choice);
+            }
+            return null;
+        });
+    }
+
+    private static class AllSubclassesAction implements TreeActionElement<Collection<IType>>
+    {
+        private final Collection<IType> concreteSubclasses;
+
+        public AllSubclassesAction(Collection<IType> concreteSubclasses)
+        {
+            this.concreteSubclasses = concreteSubclasses;
+        }
+
+        @Override
+        public boolean provideElement()
+        {
+            return true;
+        }
+
+        @Override
+        public Collection<IType> execute()
+        {
+            return concreteSubclasses;
+        }
+
+        @Override
+        public String getText()
+        {
+            return "All concrete subclasses";
+        }
+
+        @Override
+        public Image getImage()
+        {
+            return null;
+        }
     }
 
     /**

--- a/org.moreunit.plugin/src/org/moreunit/launch/JUnitTestSelectionLaunchConfigurationDelegate.java
+++ b/org.moreunit.plugin/src/org/moreunit/launch/JUnitTestSelectionLaunchConfigurationDelegate.java
@@ -18,26 +18,16 @@ import org.eclipse.jdt.junit.launcher.JUnitLaunchConfigurationDelegate;
  */
 class JUnitTestSelectionLaunchConfigurationDelegate extends JUnitLaunchConfigurationDelegate
 {
-    private final Collection<IType> testCasesToRun;
+    private final Collection<IMember> testMembersToRun;
 
     JUnitTestSelectionLaunchConfigurationDelegate(Collection< ? extends IMember> testsToRun)
     {
-        testCasesToRun = getTestCases(testsToRun);
-    }
-
-    private Collection<IType> getTestCases(Collection< ? extends IMember> testsToRun)
-    {
-        Collection<IType> testCases = new LinkedHashSet<IType>();
-        for (IMember testMember : testsToRun)
-        {
-            testCases.add(testMember instanceof IType ? (IType) testMember : testMember.getDeclaringType());
-        }
-        return testCases;
+        testMembersToRun = new LinkedHashSet<>(testsToRun);
     }
 
     @Override
     protected IMember[] evaluateTests(ILaunchConfiguration configuration, IProgressMonitor monitor) throws CoreException
     {
-        return testCasesToRun.toArray(new IMember[0]);
+        return testMembersToRun.toArray(new IMember[0]);
     }
 }

--- a/org.moreunit.plugin/src/org/moreunit/util/SearchTools.java
+++ b/org.moreunit.plugin/src/org/moreunit/util/SearchTools.java
@@ -9,7 +9,11 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.ITypeHierarchy;
+import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.search.IJavaSearchScope;
 import org.eclipse.jdt.core.search.SearchEngine;
 import org.eclipse.jdt.core.search.SearchMatch;
@@ -29,6 +33,21 @@ public class SearchTools
     public static Set<IType> searchFor(Collection<String> typeNamePatterns, IJavaSearchScope scope) throws CoreException
     {
         return search(createSearchPattern(typeNamePatterns, TYPE, DECLARATIONS, R_PATTERN_MATCH), scope);
+    }
+
+    public static Set<IType> findConcreteSubclasses(IType type) throws JavaModelException
+    {
+        Set<IType> concreteSubclasses = new LinkedHashSet<>();
+        ITypeHierarchy hierarchy = type.newTypeHierarchy(new NullProgressMonitor());
+        IType[] subtypes = hierarchy.getAllSubtypes(type);
+        for (IType subtype : subtypes)
+        {
+            if(! Flags.isAbstract(subtype.getFlags()) && ! Flags.isInterface(subtype.getFlags()))
+            {
+                concreteSubclasses.add(subtype);
+            }
+        }
+        return concreteSubclasses;
     }
 
     private static Set<IType> search(SearchPattern pattern, IJavaSearchScope scope) throws CoreException

--- a/org.moreunit.test.dependencies/src/org/moreunit/test/context/AnnotationConfigExtractor.java
+++ b/org.moreunit.test.dependencies/src/org/moreunit/test/context/AnnotationConfigExtractor.java
@@ -265,6 +265,10 @@ class AnnotationConfigExtractor
                 {
                     types.add(JavaType.newEnum(packageName, typeDef.substring(5)));
                 }
+                else if(typeDef.startsWith("interface "))
+                {
+                    types.add(JavaType.newInterface(packageName, typeDef.substring(10)));
+                }
                 else if(typeDef.startsWith("class "))
                 {
                     types.add(JavaType.newClass(packageName, typeDef.substring(6)));

--- a/org.moreunit.test.dependencies/src/org/moreunit/test/workspace/JavaType.java
+++ b/org.moreunit.test.dependencies/src/org/moreunit/test/workspace/JavaType.java
@@ -27,6 +27,11 @@ public class JavaType
         return new JavaType(JavaTypeKind.CLASS, packageName, typeName);
     }
 
+    public static JavaType newInterface(String packageName, String typeName)
+    {
+        return new JavaType(JavaTypeKind.INTERFACE, packageName, typeName);
+    }
+
     @Override
     public int hashCode()
     {

--- a/org.moreunit.test.dependencies/src/org/moreunit/test/workspace/JavaTypeKind.java
+++ b/org.moreunit.test.dependencies/src/org/moreunit/test/workspace/JavaTypeKind.java
@@ -2,7 +2,7 @@ package org.moreunit.test.workspace;
 
 public enum JavaTypeKind
 {
-    CLASS, ENUM;
+    CLASS, ENUM, INTERFACE;
 
     String toJavaCode()
     {

--- a/org.moreunit.test.dependencies/src/org/moreunit/test/workspace/SourceFolderHandler.java
+++ b/org.moreunit.test.dependencies/src/org/moreunit/test/workspace/SourceFolderHandler.java
@@ -67,6 +67,10 @@ public class SourceFolderHandler implements ElementHandler<IPackageFragmentRoot,
             {
                 type = WorkspaceHelper.createJavaClass(packageFragment, javaType.typeName);
             }
+            else if(javaType.typeKind == JavaTypeKind.INTERFACE)
+            {
+                type = WorkspaceHelper.createJavaInterface(packageFragment, javaType.typeName);
+            }
             else
             {
                 type = WorkspaceHelper.createJavaEnum(packageFragment, javaType.typeName);
@@ -88,6 +92,11 @@ public class SourceFolderHandler implements ElementHandler<IPackageFragmentRoot,
     public TypeHandler createEnum(String fullyQualifiedTypeName)
     {
         return createType(JavaTypeKind.ENUM, fullyQualifiedTypeName);
+    }
+
+    public TypeHandler createInterface(String fullyQualifiedTypeName)
+    {
+        return createType(JavaTypeKind.INTERFACE, fullyQualifiedTypeName);
     }
 
     public CompilationUnitHandler createCompilationUnit(String fullyQualifiedTypeName, String contents)
@@ -112,6 +121,10 @@ public class SourceFolderHandler implements ElementHandler<IPackageFragmentRoot,
         if(typeKind == JavaTypeKind.ENUM)
         {
             return createType(JavaType.newEnum(name.packageName, name.typeName));
+        }
+        if(typeKind == JavaTypeKind.INTERFACE)
+        {
+            return createType(JavaType.newInterface(name.packageName, name.typeName));
         }
         return createType(JavaType.newClass(name.packageName, name.typeName));
     }

--- a/org.moreunit.test.dependencies/src/org/moreunit/test/workspace/WorkspaceHelper.java
+++ b/org.moreunit.test.dependencies/src/org/moreunit/test/workspace/WorkspaceHelper.java
@@ -189,6 +189,11 @@ public class WorkspaceHelper
         return createJavaType(packageFragment, javaClassName, JavaTypeKind.ENUM);
     }
 
+    public static IType createJavaInterface(IPackageFragment packageFragment, String javaClassName) throws JavaModelException
+    {
+        return createJavaType(packageFragment, javaClassName, JavaTypeKind.INTERFACE);
+    }
+
     private static IType createJavaType(IPackageFragment packageFragment, String javaClassName, JavaTypeKind type) throws JavaModelException
     {
         String sourceCode = String.format("%s%s%s", getPackageDeclarationString(packageFragment), NEW_LINE, getTypeDeclarationString(type, javaClassName));

--- a/org.moreunit.test/test/org/moreunit/util/SearchToolsTest.java
+++ b/org.moreunit.test/test/org/moreunit/util/SearchToolsTest.java
@@ -1,0 +1,67 @@
+package org.moreunit.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+
+import org.eclipse.jdt.core.IType;
+import org.junit.Test;
+import org.moreunit.test.context.ContextTestCase;
+import org.moreunit.test.context.Project;
+
+import org.moreunit.test.workspace.TypeHandler;
+
+public class SearchToolsTest extends ContextTestCase
+{
+    @Project(mainCls = "AbstractTest")
+    @Test
+    public void findConcreteSubclasses_should_find_all_concrete_subclasses() throws Exception
+    {
+        TypeHandler abstractTypeHandler = context.getPrimaryTypeHandler("AbstractTest");
+        abstractTypeHandler.get().getCompilationUnit().getBuffer().setContents("public abstract class AbstractTest {}");
+        abstractTypeHandler.get().getCompilationUnit().save(null, true);
+
+        abstractTypeHandler.createSubclass("ConcreteTest");
+        abstractTypeHandler.createSubclass("AnotherConcreteTest");
+        TypeHandler anotherAbstractTypeHandler = abstractTypeHandler.createSubclass("AnotherAbstractTest");
+        anotherAbstractTypeHandler.get().getCompilationUnit().getBuffer().setContents("public abstract class AnotherAbstractTest extends AbstractTest {}");
+        anotherAbstractTypeHandler.get().getCompilationUnit().save(null, true);
+
+        Collection<IType> concreteSubclasses = SearchTools.findConcreteSubclasses(abstractTypeHandler.get());
+
+        assertThat(concreteSubclasses).hasSize(2).extracting("elementName").containsOnly("ConcreteTest", "AnotherConcreteTest");
+    }
+
+    @Project(mainCls = "AbstractTest2")
+    @Test
+    public void findConcreteSubclasses_should_find_only_concrete_ones() throws Exception
+    {
+        TypeHandler abstractTypeHandler = context.getPrimaryTypeHandler("AbstractTest2");
+        abstractTypeHandler.get().getCompilationUnit().getBuffer().setContents("public abstract class AbstractTest2 {}");
+        abstractTypeHandler.get().getCompilationUnit().save(null, true);
+
+        abstractTypeHandler.createSubclass("ConcreteTest2");
+
+        Collection<IType> concreteSubclasses = SearchTools.findConcreteSubclasses(abstractTypeHandler.get());
+
+        assertThat(concreteSubclasses).hasSize(1).extracting("elementName").containsOnly("ConcreteTest2");
+    }
+
+    @Project(mainCls = "ITest")
+    @Test
+    public void findConcreteSubclasses_should_handle_interfaces() throws Exception
+    {
+        TypeHandler interfaceHandler = context.getPrimaryTypeHandler("ITest");
+        interfaceHandler.get().getCompilationUnit().getBuffer().setContents("public interface ITest {}");
+        interfaceHandler.get().getCompilationUnit().save(null, true);
+
+        interfaceHandler.createSubclass("ConcreteTest3");
+        TypeHandler abstractTypeHandler = interfaceHandler.createSubclass("AbstractTest3");
+        abstractTypeHandler.get().getCompilationUnit().getBuffer().setContents("public abstract class AbstractTest3 implements ITest {}");
+        abstractTypeHandler.get().getCompilationUnit().save(null, true);
+
+        Collection<IType> concreteSubclasses = SearchTools.findConcreteSubclasses(interfaceHandler.get());
+
+        assertThat(concreteSubclasses).hasSize(1).extracting("elementName").containsOnly("ConcreteTest3");
+    }
+}


### PR DESCRIPTION
This PR adds support for running tests from abstract classes. When a user tries to run tests in an abstract class (or from its corresponding Class Under Test), MoreUnit now:
1. Detects that the test class is abstract.
2. Finds all concrete subclasses.
3. If only one subclass is found, it's used automatically.
4. If multiple subclasses are found, a popup asks the user to choose one or "All concrete subclasses".
5. Remembers the last choice for subsequent runs.

This is particularly useful for test patterns where an abstract base class contains shared tests that are executed in different contexts by concrete subclasses (e.g., browser-specific tests or database-specific tests).

Changes:
- Added `SearchTools.findConcreteSubclasses` utility.
- Modified `RunTestsActionExecutor` to integrate the resolution logic.
- Improved `JUnitTestSelectionLaunchConfigurationDelegate` to handle specific `IMember` instances, enabling method-level execution in subclasses.
- Added `SearchToolsTest` and updated test framework dependencies to support the new test scenarios.

---
*PR created automatically by Jules for task [2315245454879716993](https://jules.google.com/task/2315245454879716993) started by @RoiSoleil*