### PR TITLE
Improve interface and implementation support in jump actions

### DIFF
--- a/org.moreunit.plugin/src/org/moreunit/matching/CorrespondingTypeSearcher.java
+++ b/org.moreunit.plugin/src/org/moreunit/matching/CorrespondingTypeSearcher.java
@@ -48,7 +48,7 @@ public class CorrespondingTypeSearcher
         nameEvaluation = this.preferences.getTestClassNamePattern().evaluate(this.type);
         IPackageFragmentRoot sourceFolder = nameEvaluation.isTestCase()
             ? preferences.getTestSourceFolder(compilationUnit.getJavaProject(), PluginTools.getSourceFolder(compilationUnit))
-            : preferences.getMainSourceFolder(compilationUnit.getJavaProject(), PluginTools.getSourceFolder(compilationUnit));
+            : this.preferences.getMainSourceFolder(PluginTools.getSourceFolder(compilationUnit));
         searchScope = SearchScopeSingelton.getInstance().getSearchScope(sourceFolder);
     }
 
@@ -102,13 +102,11 @@ public class CorrespondingTypeSearcher
 
                 if(type.isInterface() || Flags.isAbstract(type.getFlags()))
                 {
-                    for (IType subType : hierarchy.getAllSubtypes(type))
+                    Set<IType> foundConcrete = SearchTools.findConcreteSubclasses(type, searchScope);
+                    for (IType subType : foundConcrete)
                     {
-                        if(! Flags.isAbstract(subType.getFlags()) && ! subType.isInterface())
-                        {
-                            ClassNameEvaluation subEval = preferences.getTestClassNamePattern().evaluate(subType);
-                            patterns.addAll(subEval.getAllCorrespondingClassPatterns(qualifyWithPackage));
-                        }
+                        ClassNameEvaluation subEval = preferences.getTestClassNamePattern().evaluate(subType);
+                        patterns.addAll(subEval.getAllCorrespondingClassPatterns(qualifyWithPackage));
                     }
                 }
             }
@@ -130,7 +128,7 @@ public class CorrespondingTypeSearcher
                 {
                     if(match.isInterface() || Flags.isAbstract(match.getFlags()))
                     {
-                        concreteImplementations.addAll(SearchTools.findConcreteSubclasses(match));
+                        concreteImplementations.addAll(SearchTools.findConcreteSubclasses(match, searchScope));
                     }
                 }
                 catch (JavaModelException e)

--- a/org.moreunit.plugin/src/org/moreunit/matching/CorrespondingTypeSearcher.java
+++ b/org.moreunit.plugin/src/org/moreunit/matching/CorrespondingTypeSearcher.java
@@ -102,11 +102,14 @@ public class CorrespondingTypeSearcher
 
                 if(type.isInterface() || Flags.isAbstract(type.getFlags()))
                 {
-                    Set<IType> foundConcrete = SearchTools.findConcreteSubclasses(type, searchScope);
-                    for (IType subType : foundConcrete)
+                    IType[] subtypes = hierarchy.getAllSubtypes(type);
+                    for (IType subType : subtypes)
                     {
-                        ClassNameEvaluation subEval = preferences.getTestClassNamePattern().evaluate(subType);
-                        patterns.addAll(subEval.getAllCorrespondingClassPatterns(qualifyWithPackage));
+                        if(! Flags.isAbstract(subType.getFlags()) && ! subType.isInterface())
+                        {
+                            ClassNameEvaluation subEval = preferences.getTestClassNamePattern().evaluate(subType);
+                            patterns.addAll(subEval.getAllCorrespondingClassPatterns(qualifyWithPackage));
+                        }
                     }
                 }
             }
@@ -128,7 +131,7 @@ public class CorrespondingTypeSearcher
                 {
                     if(match.isInterface() || Flags.isAbstract(match.getFlags()))
                     {
-                        concreteImplementations.addAll(SearchTools.findConcreteSubclasses(match, searchScope));
+                        concreteImplementations.addAll(SearchTools.findConcreteSubclasses(match));
                     }
                 }
                 catch (JavaModelException e)

--- a/org.moreunit.plugin/src/org/moreunit/matching/CorrespondingTypeSearcher.java
+++ b/org.moreunit.plugin/src/org/moreunit/matching/CorrespondingTypeSearcher.java
@@ -3,11 +3,19 @@ package org.moreunit.matching;
 import static java.util.Collections.emptySet;
 
 import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jdt.core.Flags;
 import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.ITypeHierarchy;
+import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.search.IJavaSearchScope;
 import org.moreunit.log.LogHandler;
 import org.moreunit.preferences.Preferences;
@@ -26,6 +34,7 @@ import org.moreunit.util.SearchTools;
  */
 public class CorrespondingTypeSearcher
 {
+    private final IType type;
     private final ProjectPreferences preferences;
     private final ClassNameEvaluation nameEvaluation;
     private final IJavaSearchScope searchScope;
@@ -34,8 +43,9 @@ public class CorrespondingTypeSearcher
 
     public CorrespondingTypeSearcher(ICompilationUnit compilationUnit, Preferences preferences)
     {
+        this.type = compilationUnit.findPrimaryType();
         this.preferences = preferences.getProjectView(compilationUnit.getJavaProject());
-        nameEvaluation = this.preferences.getTestClassNamePattern().evaluate(compilationUnit.findPrimaryType());
+        nameEvaluation = this.preferences.getTestClassNamePattern().evaluate(this.type);
         IPackageFragmentRoot sourceFolder = nameEvaluation.isTestCase()
             ? preferences.getTestSourceFolder(compilationUnit.getJavaProject(), PluginTools.getSourceFolder(compilationUnit))
             : preferences.getMainSourceFolder(compilationUnit.getJavaProject(), PluginTools.getSourceFolder(compilationUnit));
@@ -74,6 +84,101 @@ public class CorrespondingTypeSearcher
     private Collection<IType> findPotentialTargets(boolean withLikelyMatches) throws CoreException
     {
         boolean qualifyWithPackage = ! withLikelyMatches;
-        return SearchTools.searchFor(nameEvaluation.getAllCorrespondingClassPatterns(qualifyWithPackage), searchScope);
+        Set<String> patterns = new LinkedHashSet<>(nameEvaluation.getAllCorrespondingClassPatterns(qualifyWithPackage));
+
+        if(type != null && ! nameEvaluation.isTestCase())
+        {
+            try
+            {
+                ITypeHierarchy hierarchy = type.newTypeHierarchy(new NullProgressMonitor());
+                for (IType superType : hierarchy.getAllSupertypes(type))
+                {
+                    if(! superType.getFullyQualifiedName().startsWith("java.lang."))
+                    {
+                        ClassNameEvaluation superEval = preferences.getTestClassNamePattern().evaluate(superType);
+                        patterns.addAll(superEval.getAllCorrespondingClassPatterns(qualifyWithPackage));
+                    }
+                }
+
+                if(type.isInterface() || Flags.isAbstract(type.getFlags()))
+                {
+                    for (IType subType : hierarchy.getAllSubtypes(type))
+                    {
+                        if(! Flags.isAbstract(subType.getFlags()) && ! subType.isInterface())
+                        {
+                            ClassNameEvaluation subEval = preferences.getTestClassNamePattern().evaluate(subType);
+                            patterns.addAll(subEval.getAllCorrespondingClassPatterns(qualifyWithPackage));
+                        }
+                    }
+                }
+            }
+            catch (JavaModelException e)
+            {
+                LogHandler.getInstance().handleExceptionLog(e);
+            }
+        }
+
+        Set<IType> matches = SearchTools.searchFor(patterns, searchScope);
+
+        if(nameEvaluation.isTestCase())
+        {
+            Set<IType> allMatches = new LinkedHashSet<>(matches);
+            Set<IType> concreteImplementations = new LinkedHashSet<>();
+            for (IType match : matches)
+            {
+                try
+                {
+                    if(match.isInterface() || Flags.isAbstract(match.getFlags()))
+                    {
+                        concreteImplementations.addAll(SearchTools.findConcreteSubclasses(match));
+                    }
+                }
+                catch (JavaModelException e)
+                {
+                    // ignore
+                }
+            }
+
+            if(! concreteImplementations.isEmpty())
+            {
+                allMatches.addAll(concreteImplementations);
+
+                for (Iterator<IType> it = allMatches.iterator(); it.hasNext();)
+                {
+                    IType match = it.next();
+                    try
+                    {
+                        if((match.isInterface() || Flags.isAbstract(match.getFlags())) && ! hasImplementation(match))
+                        {
+                            it.remove();
+                        }
+                    }
+                    catch (JavaModelException e)
+                    {
+                        // ignore
+                    }
+                }
+            }
+
+            return allMatches;
+        }
+
+        return matches;
+    }
+
+    private boolean hasImplementation(IType type) throws JavaModelException
+    {
+        for (IMethod method : type.getMethods())
+        {
+            if(Flags.isDefaultMethod(method.getFlags()))
+            {
+                return true;
+            }
+            if(! Flags.isAbstract(method.getFlags()) && ! type.isInterface())
+            {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/org.moreunit.plugin/src/org/moreunit/matching/CorrespondingTypeSearcher.java
+++ b/org.moreunit.plugin/src/org/moreunit/matching/CorrespondingTypeSearcher.java
@@ -86,6 +86,13 @@ public class CorrespondingTypeSearcher
         boolean qualifyWithPackage = ! withLikelyMatches;
         Set<String> patterns = new LinkedHashSet<>(nameEvaluation.getAllCorrespondingClassPatterns(qualifyWithPackage));
 
+        Set<IType> matches = SearchTools.searchFor(patterns, searchScope);
+
+        if(matches.size() == 1 && ! matches.iterator().next().isInterface())
+        {
+            return matches;
+        }
+
         if(type != null && ! nameEvaluation.isTestCase())
         {
             try
@@ -119,7 +126,7 @@ public class CorrespondingTypeSearcher
             }
         }
 
-        Set<IType> matches = SearchTools.searchFor(patterns, searchScope);
+        matches = SearchTools.searchFor(patterns, searchScope);
 
         if(nameEvaluation.isTestCase())
         {

--- a/org.moreunit.plugin/src/org/moreunit/util/SearchTools.java
+++ b/org.moreunit.plugin/src/org/moreunit/util/SearchTools.java
@@ -37,27 +37,15 @@ public class SearchTools
 
     public static Set<IType> findConcreteSubclasses(IType type) throws JavaModelException
     {
-        return findConcreteSubclasses(type, SearchEngine.createWorkspaceScope());
-    }
-
-    public static Set<IType> findConcreteSubclasses(IType type, IJavaSearchScope scope)
-    {
         Set<IType> concreteSubclasses = new LinkedHashSet<>();
-        try
+        ITypeHierarchy hierarchy = type.newTypeHierarchy(new NullProgressMonitor());
+        IType[] subtypes = hierarchy.getAllSubtypes(type);
+        for (IType subtype : subtypes)
         {
-            SearchPattern pattern = SearchPattern.createPattern(type, IMPLEMENTORS);
-            Set<IType> found = search(pattern, scope);
-            for (IType t : found)
+            if(! Flags.isAbstract(subtype.getFlags()) && ! Flags.isInterface(subtype.getFlags()))
             {
-                if(! Flags.isAbstract(t.getFlags()) && ! t.isInterface())
-                {
-                    concreteSubclasses.add(t);
-                }
+                concreteSubclasses.add(subtype);
             }
-        }
-        catch (CoreException e)
-        {
-            // ignore
         }
         return concreteSubclasses;
     }

--- a/org.moreunit.plugin/src/org/moreunit/util/SearchTools.java
+++ b/org.moreunit.plugin/src/org/moreunit/util/SearchTools.java
@@ -37,20 +37,32 @@ public class SearchTools
 
     public static Set<IType> findConcreteSubclasses(IType type) throws JavaModelException
     {
+        return findConcreteSubclasses(type, SearchEngine.createWorkspaceScope());
+    }
+
+    public static Set<IType> findConcreteSubclasses(IType type, IJavaSearchScope scope)
+    {
         Set<IType> concreteSubclasses = new LinkedHashSet<>();
-        ITypeHierarchy hierarchy = type.newTypeHierarchy(new NullProgressMonitor());
-        IType[] subtypes = hierarchy.getAllSubtypes(type);
-        for (IType subtype : subtypes)
+        try
         {
-            if(! Flags.isAbstract(subtype.getFlags()) && ! Flags.isInterface(subtype.getFlags()))
+            SearchPattern pattern = SearchPattern.createPattern(type, IMPLEMENTORS);
+            Set<IType> found = search(pattern, scope);
+            for (IType t : found)
             {
-                concreteSubclasses.add(subtype);
+                if(! Flags.isAbstract(t.getFlags()) && ! t.isInterface())
+                {
+                    concreteSubclasses.add(t);
+                }
             }
+        }
+        catch (CoreException e)
+        {
+            // ignore
         }
         return concreteSubclasses;
     }
 
-    private static Set<IType> search(SearchPattern pattern, IJavaSearchScope scope) throws CoreException
+    public static Set<IType> search(SearchPattern pattern, IJavaSearchScope scope) throws CoreException
     {
         SearchParticipant[] participants = new SearchParticipant[] { SearchEngine.getDefaultSearchParticipant() };
         MatchCollector collector = new MatchCollector();

--- a/org.moreunit.test/test/org/moreunit/matching/InterfaceCorrespondingTypeSearcherTest.java
+++ b/org.moreunit.test/test/org/moreunit/matching/InterfaceCorrespondingTypeSearcherTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Collection;
 
 import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
 import org.junit.Test;
 import org.moreunit.test.context.ContextTestCase;
 import org.moreunit.test.context.Preferences;
@@ -15,7 +16,7 @@ public class InterfaceCorrespondingTypeSearcherTest extends ContextTestCase
 {
     @Project(mainCls = "class Foo", testCls = "FooTest")
     @Test
-    public void getMatches_should_return_test_for_class() throws Exception
+    public void getMatches_should_return_test_for_class()
     {
         CorrespondingTypeSearcher searcher = new CorrespondingTypeSearcher(context.getCompilationUnit("Foo"), getPreferences());
         Collection<IType> matches = searcher.getMatches(false);
@@ -25,7 +26,7 @@ public class InterfaceCorrespondingTypeSearcherTest extends ContextTestCase
 
     @Project(mainCls = "interface Foo", testCls = "FooTest")
     @Test
-    public void getMatches_should_return_test_for_interface() throws Exception
+    public void getMatches_should_return_test_for_interface()
     {
         context.getPrimaryTypeHandler("Foo").createSubclass("FooImpl");
 
@@ -37,7 +38,7 @@ public class InterfaceCorrespondingTypeSearcherTest extends ContextTestCase
 
     @Project(mainCls = "interface Foo", testCls = "FooTest")
     @Test
-    public void getMatches_should_return_implementation_for_interface_test_and_exclude_interface() throws Exception
+    public void getMatches_should_return_implementation_for_interface_test_and_exclude_interface()
     {
         context.getPrimaryTypeHandler("Foo").createSubclass("FooImpl");
 
@@ -50,7 +51,7 @@ public class InterfaceCorrespondingTypeSearcherTest extends ContextTestCase
 
     @Project(mainCls = "interface Foo", testCls = "FooTest")
     @Test
-    public void getMatches_should_return_interface_test_for_implementation() throws Exception
+    public void getMatches_should_return_interface_test_for_implementation()
     {
         context.getPrimaryTypeHandler("Foo").createSubclass("FooImpl");
 
@@ -62,7 +63,7 @@ public class InterfaceCorrespondingTypeSearcherTest extends ContextTestCase
 
     @Project(mainCls = "interface Foo")
     @Test
-    public void getMatches_should_return_interface_for_implementation_test() throws Exception
+    public void getMatches_should_return_interface_for_implementation_test()
     {
         context.getPrimaryTypeHandler("Foo").createSubclass("FooImpl");
         context.getProjectHandler().getTestSrcFolderHandler().createClass("FooImplTest");
@@ -75,7 +76,7 @@ public class InterfaceCorrespondingTypeSearcherTest extends ContextTestCase
 
     @Project(mainCls = "interface Foo", testCls = "FooTest")
     @Test
-    public void getMatches_should_include_interface_if_it_has_default_method() throws Exception
+    public void getMatches_should_include_interface_if_it_has_default_method() throws JavaModelException
     {
         IType foo = context.getPrimaryTypeHandler("Foo").get();
         foo.createMethod("default void bar() {}", null, true, null);

--- a/org.moreunit.test/test/org/moreunit/matching/InterfaceCorrespondingTypeSearcherTest.java
+++ b/org.moreunit.test/test/org/moreunit/matching/InterfaceCorrespondingTypeSearcherTest.java
@@ -1,0 +1,90 @@
+package org.moreunit.matching;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+
+import org.eclipse.jdt.core.IType;
+import org.junit.Test;
+import org.moreunit.test.context.ContextTestCase;
+import org.moreunit.test.context.Preferences;
+import org.moreunit.test.context.Project;
+
+@Preferences(testClassNameTemplate = "${srcFile}Test", testSrcFolder = "test")
+public class InterfaceCorrespondingTypeSearcherTest extends ContextTestCase
+{
+    @Project(mainCls = "class Foo", testCls = "FooTest")
+    @Test
+    public void getMatches_should_return_test_for_class() throws Exception
+    {
+        CorrespondingTypeSearcher searcher = new CorrespondingTypeSearcher(context.getCompilationUnit("Foo"), getPreferences());
+        Collection<IType> matches = searcher.getMatches(false);
+
+        assertThat(matches).extracting("elementName").containsExactly("FooTest");
+    }
+
+    @Project(mainCls = "interface Foo", testCls = "FooTest")
+    @Test
+    public void getMatches_should_return_test_for_interface() throws Exception
+    {
+        context.getPrimaryTypeHandler("Foo").createSubclass("FooImpl");
+
+        CorrespondingTypeSearcher searcher = new CorrespondingTypeSearcher(context.getCompilationUnit("Foo"), getPreferences());
+        Collection<IType> matches = searcher.getMatches(false);
+
+        assertThat(matches).extracting("elementName").containsExactly("FooTest");
+    }
+
+    @Project(mainCls = "interface Foo", testCls = "FooTest")
+    @Test
+    public void getMatches_should_return_implementation_for_interface_test_and_exclude_interface() throws Exception
+    {
+        context.getPrimaryTypeHandler("Foo").createSubclass("FooImpl");
+
+        CorrespondingTypeSearcher searcher = new CorrespondingTypeSearcher(context.getCompilationUnit("FooTest"), getPreferences());
+        Collection<IType> matches = searcher.getMatches(false);
+
+        // Should return FooImpl and EXCLUDE Foo because Foo is a pure interface
+        assertThat(matches).extracting("elementName").containsExactly("FooImpl");
+    }
+
+    @Project(mainCls = "interface Foo", testCls = "FooTest")
+    @Test
+    public void getMatches_should_return_interface_test_for_implementation() throws Exception
+    {
+        context.getPrimaryTypeHandler("Foo").createSubclass("FooImpl");
+
+        CorrespondingTypeSearcher searcher = new CorrespondingTypeSearcher(context.getCompilationUnit("FooImpl"), getPreferences());
+        Collection<IType> matches = searcher.getMatches(false);
+
+        assertThat(matches).extracting("elementName").contains("FooTest");
+    }
+
+    @Project(mainCls = "interface Foo")
+    @Test
+    public void getMatches_should_return_interface_for_implementation_test() throws Exception
+    {
+        context.getPrimaryTypeHandler("Foo").createSubclass("FooImpl");
+        context.getProjectHandler().getTestSrcFolderHandler().createClass("FooImplTest");
+
+        CorrespondingTypeSearcher searcher = new CorrespondingTypeSearcher(context.getCompilationUnit("FooImplTest"), getPreferences());
+        Collection<IType> matches = searcher.getMatches(false);
+
+        assertThat(matches).extracting("elementName").containsExactly("FooImpl");
+    }
+
+    @Project(mainCls = "interface Foo", testCls = "FooTest")
+    @Test
+    public void getMatches_should_include_interface_if_it_has_default_method() throws Exception
+    {
+        IType foo = context.getPrimaryTypeHandler("Foo").get();
+        foo.createMethod("default void bar() {}", null, true, null);
+        context.getPrimaryTypeHandler("Foo").createSubclass("FooImpl");
+
+        CorrespondingTypeSearcher searcher = new CorrespondingTypeSearcher(context.getCompilationUnit("FooTest"), getPreferences());
+        Collection<IType> matches = searcher.getMatches(false);
+
+        // Should return both Foo and FooImpl because Foo has a default method
+        assertThat(matches).extracting("elementName").containsExactlyInAnyOrder("Foo", "FooImpl");
+    }
+}


### PR DESCRIPTION
The "Jump to Test/Code" functionality in MoreUnit now better supports interfaces and their implementations.

Key changes:
1.  **Supertypes Search:** When searching for tests for a class, MoreUnit now also considers tests for its superclasses and interfaces (excluding `java.lang.*`). This allows jumping from a class like `FooImpl` to `FooTest` if `FooImpl` implements `Foo`.
2.  **Implementation Discovery:** When searching for the code under test from a test class, MoreUnit now includes concrete implementations of any matched interface or abstract class.
3.  **Refined UX for Interfaces:** To avoid jumping to "empty" interfaces when concrete code exists, MoreUnit will now exclude interfaces or abstract classes from the jump targets if:
    -   At least one concrete implementation was found.
    -   The interface/abstract class itself contains no non-abstract methods (e.g., no default methods in an interface).
4.  **Unit Tests:** Added `InterfaceCorrespondingTypeSearcherTest` to verify these navigation scenarios.

---
*PR created automatically by Jules for task [18132929899494660556](https://jules.google.com/task/18132929899494660556) started by @RoiSoleil*