### PR TITLE
🔒 Fix e.printStackTrace security and logging vulnerability

### DIFF
--- a/org.moreunit.plugin/src/org/moreunit/elements/MissingClassTreeContentProvider.java
+++ b/org.moreunit.plugin/src/org/moreunit/elements/MissingClassTreeContentProvider.java
@@ -13,6 +13,7 @@ import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.Viewer;
+import org.moreunit.log.LogHandler;
 import org.moreunit.ui.MissingTestsViewPart;
 import org.moreunit.util.PluginTools;
 
@@ -41,7 +42,7 @@ public class MissingClassTreeContentProvider implements ITreeContentProvider
         }
         catch (JavaModelException e)
         {
-            e.printStackTrace();
+            LogHandler.getInstance().handleExceptionLog(e);
         }
         }
         return null;
@@ -94,7 +95,7 @@ public class MissingClassTreeContentProvider implements ITreeContentProvider
                     }
                     catch (JavaModelException e)
                     {
-                        e.printStackTrace();
+                        LogHandler.getInstance().handleExceptionLog(e);
                     }
                 }
             }

--- a/org.moreunit.test/test/org/moreunit/elements/MissingClassTreeContentProviderTest.java
+++ b/org.moreunit.test/test/org/moreunit/elements/MissingClassTreeContentProviderTest.java
@@ -1,0 +1,25 @@
+package org.moreunit.elements;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IPackageFragment;
+import org.eclipse.jdt.core.JavaModelException;
+import org.junit.Test;
+
+public class MissingClassTreeContentProviderTest
+{
+    @Test
+    public void should_not_throw_exception_but_return_null_when_java_model_exception_occurs() throws JavaModelException
+    {
+        MissingClassTreeContentProvider provider = new MissingClassTreeContentProvider();
+        IPackageFragment mockFragment = mock(IPackageFragment.class);
+        when(mockFragment.getCompilationUnits()).thenThrow(new JavaModelException(new RuntimeException("Test exception"), 1));
+
+        Object[] result = provider.getChildren(mockFragment);
+
+        assertThat(result).isNull();
+    }
+}


### PR DESCRIPTION
🎯 **What:** Replaced `e.printStackTrace()` with application logging in `MissingClassTreeContentProvider.java`.
⚠️ **Risk:** Uncaught exceptions dumping stack traces directly to `stderr` could leak sensitive internal application states or paths. Additionally, it circumvents proper centralized logging, making debugging and log collection difficult.
🛡️ **Solution:** Replaced occurrences of `e.printStackTrace()` with the project's standard logging handler (`LogHandler.getInstance().handleExceptionLog(e)`).

---
*PR created automatically by Jules for task [7617293081472418907](https://jules.google.com/task/7617293081472418907) started by @RoiSoleil*