### PR TITLE
🧪 Add error path test for Exception in loadTemplate

### DIFF
--- a/org.moreunit.mock.test/test/org/moreunit/mock/templates/MockingTemplateLoaderTest.java
+++ b/org.moreunit.mock.test/test/org/moreunit/mock/templates/MockingTemplateLoaderTest.java
@@ -59,6 +59,27 @@ public class MockingTemplateLoaderTest
     }
 
     @Test
+    public void should_log_error_and_add_to_invalid_templates_when_generic_exception_occurs() throws Exception
+    {
+        // given
+        URL definitionUrl = URI.create("file:/generic.exception.url").toURL();
+        RuntimeException genericException = new RuntimeException("generic exception");
+
+        when(resourceLoader.findBundleResources(eq(TEMPLATE_DIRECTORY), anyString())).thenReturn(singleton(definitionUrl));
+        when(resourceLoader.findWorkspaceStateResources(anyString(), anyString())).thenReturn(noResources);
+
+        when(templateDefinitionReader.read(definitionUrl)).thenThrow(genericException);
+
+        // when
+        LoadingResult result = loader.loadTemplates();
+
+        // then
+        verify(logger).error(anyString(), eq(genericException));
+        assertThat(result.invalidTemplatesFound()).isTrue();
+        assertThat(result.invalidTemplates()).contains(entry(definitionUrl, genericException.toString()));
+    }
+
+    @Test
     public void should_log_error_when_template_definition_is_invalid() throws Exception
     {
         // given


### PR DESCRIPTION
🎯 **What:** Missing error path test for generic Exception in `MockingTemplateLoader.loadTemplate`.
📊 **Coverage:** Added `should_log_error_and_add_to_invalid_templates_when_generic_exception_occurs` to cover the catch-all `Exception` block.
✨ **Result:** Increased reliability and verification of the error handling path for unexpected exceptions during template loading.

---
*PR created automatically by Jules for task [8602985085122927988](https://jules.google.com/task/8602985085122927988) started by @RoiSoleil*