### PR TITLE
🧪 Add tests for MockingContext hasDependenciesToMock

### DIFF
--- a/org.moreunit.mock.test/test/org/moreunit/mock/templates/MockingContextTest.java
+++ b/org.moreunit.mock.test/test/org/moreunit/mock/templates/MockingContextTest.java
@@ -37,7 +37,6 @@ import org.moreunit.mock.model.Part;
 import org.moreunit.mock.model.SetterDependency;
 import org.moreunit.preferences.PreferenceConstants;
 
-@Ignore
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class MockingContextTest
 {
@@ -317,6 +316,32 @@ public class MockingContextTest
         verify(templateProcessor, never()).applyTemplate(codeTemplate, mockingContext);
 
         assertThat(mockingContext.getBeforeInstanceMethodName()).isNull();
+    }
+
+    @Test
+    public void should_return_true_when_has_dependencies_to_mock() throws Exception
+    {
+        // given
+        dependencies.add(new Dependency("pack.age.Type", "aType"));
+
+        // when
+        mockingContext = createMockingContext();
+
+        // then
+        assertThat(mockingContext.hasDependenciesToMock()).isTrue();
+    }
+
+    @Test
+    public void should_return_false_when_has_no_dependencies_to_mock() throws Exception
+    {
+        // given
+        // dependencies is empty
+
+        // when
+        mockingContext = createMockingContext();
+
+        // then
+        assertThat(mockingContext.hasDependenciesToMock()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: added tests to `MockingContext.java`'s `hasDependenciesToMock` method, which was previously missing a unit test. I also removed `@Ignore` from `MockingContextTest` to run the test suite for this file.
📊 **Coverage:** What scenarios are now tested: Both the case where dependencies are not empty and the case where dependencies are empty.
✨ **Result:** The improvement in test coverage: Coverage has improved for this file.

---
*PR created automatically by Jules for task [6866145684931438383](https://jules.google.com/task/6866145684931438383) started by @RoiSoleil*