### PR TITLE
Force re-decoration on preferences change

### DIFF
--- a/org.moreunit.plugin/src/org/moreunit/MoreUnitPlugin.java
+++ b/org.moreunit.plugin/src/org/moreunit/MoreUnitPlugin.java
@@ -6,12 +6,14 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.ui.IPartService;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.moreunit.annotation.AnnotationUpdateListener;
 import org.moreunit.annotation.MoreUnitAnnotationModel;
+import org.moreunit.decorator.UnitDecorator;
 import org.moreunit.core.log.DefaultLogger;
 import org.moreunit.core.log.Logger;
 import org.moreunit.log.LogHandler;
@@ -34,6 +36,7 @@ public class MoreUnitPlugin extends AbstractUIPlugin
 
     private Logger logger;
     private AnnotationUpdateListener annotationUpdateListener;
+    private IPropertyChangeListener propertyChangeListener;
 
     /**
      * The constructor.
@@ -66,6 +69,9 @@ public class MoreUnitPlugin extends AbstractUIPlugin
 
         MoreUnitAnnotationModel.attachForAllOpenEditor();
         removeMarkerFromOlderMoreUnitVersions();
+
+        propertyChangeListener = event -> UnitDecorator.refreshAll();
+        getPreferenceStore().addPropertyChangeListener(propertyChangeListener);
     }
 
     protected IPartService getPartService()
@@ -109,6 +115,11 @@ public class MoreUnitPlugin extends AbstractUIPlugin
         IPartService partService = getPartService();
         if(partService != null)
             partService.removePartListener(annotationUpdateListener);
+
+        if(propertyChangeListener != null)
+        {
+            getPreferenceStore().removePropertyChangeListener(propertyChangeListener);
+        }
 
         plugin = null;
     }

--- a/org.moreunit.plugin/src/org/moreunit/decorator/UnitDecorator.java
+++ b/org.moreunit.plugin/src/org/moreunit/decorator/UnitDecorator.java
@@ -22,7 +22,6 @@ import org.moreunit.util.MoreUnitContants;
  * Handles the decoration of java files. If the class has a testcase a overlay
  * icon is added.
  */
-// TODO force re-decoration on preferences change (use refreshAll)
 public class UnitDecorator extends LabelProvider implements ILightweightLabelDecorator
 {
     private final Logger logger;
@@ -150,11 +149,15 @@ public class UnitDecorator extends LabelProvider implements ILightweightLabelDec
             return null;
     }
 
-    public void refreshAll()
+    public static void refreshAll()
     {
-        UnitDecorator unitDecorator = getUnitDecorator();
+        PlatformUI.getWorkbench().getDisplay().asyncExec(() -> {
+            UnitDecorator unitDecorator = getUnitDecorator();
 
-        if(unitDecorator != null)
-            unitDecorator.fireLabelProviderChanged(new LabelProviderChangedEvent(unitDecorator));
+            if(unitDecorator != null)
+            {
+                unitDecorator.fireLabelProviderChanged(new LabelProviderChangedEvent(unitDecorator));
+            }
+        });
     }
 }

--- a/org.moreunit.plugin/src/org/moreunit/properties/MoreUnitPropertyPage.java
+++ b/org.moreunit.plugin/src/org/moreunit/properties/MoreUnitPropertyPage.java
@@ -22,6 +22,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.ui.dialogs.PropertyPage;
 import org.eclipse.ui.preferences.ScopedPreferenceStore;
+import org.moreunit.decorator.UnitDecorator;
 import org.moreunit.log.LogHandler;
 import org.moreunit.preferences.Preferences;
 
@@ -189,6 +190,8 @@ public class MoreUnitPropertyPage extends PropertyPage
             IPreferenceStore store = Preferences.getInstance().getProjectStore(getJavaProject());
             if(store instanceof ScopedPreferenceStore preferenceStore)
                 preferenceStore.save();
+
+            UnitDecorator.refreshAll();
         }
         catch (IOException e)
         {

--- a/org.moreunit.plugin/src/org/moreunit/util/MoreUnitContants.java
+++ b/org.moreunit.plugin/src/org/moreunit/util/MoreUnitContants.java
@@ -10,7 +10,7 @@ import java.util.List;
 public class MoreUnitContants
 {
     public static final String TEST_CASE_MARKER = "org.moreunit.testCase";
-    public static final String TEST_CASE_DECORATOR = "moreunit.testdecorator";
+    public static final String TEST_CASE_DECORATOR = "org.moreunit.testdecorator";
 
     public static final String TEST_JUNIT3_METHOD_PRAEFIX = "test";
     public static final String SUFFIX_NAME = "Suffix";


### PR DESCRIPTION
Implemented forced re-decoration of Java elements when MoreUnit preferences or project properties change. This ensures that the test-case overlay icons are updated immediately without requiring a manual refresh or editor restart.

Changes:
- In `UnitDecorator`: Made `refreshAll()` static and wrapped the label provider change event in `asyncExec` to ensure it runs on the UI thread.
- In `MoreUnitContants`: Corrected `TEST_CASE_DECORATOR` to `"org.moreunit.testdecorator"`.
- In `MoreUnitPlugin`: Registered a `propertyChangeListener` on the plugin's preference store.
- In `MoreUnitPropertyPage`: Added a call to `UnitDecorator.refreshAll()` after saving project-specific properties.

---
*PR created automatically by Jules for task [102200140677153220](https://jules.google.com/task/102200140677153220) started by @RoiSoleil*