### PR TITLE
Fix handling of array types in dependency resolution

### DIFF
--- a/org.moreunit.mock.test/test/org/moreunit/mock/dependencies/DependenciesTest.java
+++ b/org.moreunit.mock.test/test/org/moreunit/mock/dependencies/DependenciesTest.java
@@ -3,6 +3,7 @@ package org.moreunit.mock.dependencies;
 import static java.util.Arrays.asList;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -74,7 +75,24 @@ public class DependenciesTest
         assertThat(dependencies.resolveTypeSignature("@NonNull Comparator<String>")).isEqualTo("java.util.Comparator");
     }
 
-    // TODO see what to do with array types (should not be mockable...)
+    @Test
+    public void should_ignore_array_types() throws Exception
+    {
+        // given
+        when(dependencyInjectionPointStore.getConstructors()).thenReturn(Collections.<IMethod> emptySet());
+        when(dependencyInjectionPointStore.getSetters()).thenReturn(Collections.<IMethod> emptySet());
+
+        IField field = mock(IField.class);
+        when(field.getTypeSignature()).thenReturn("[Ljava.lang.String;");
+
+        when(dependencyInjectionPointStore.getFields()).thenReturn(Collections.singleton(field));
+
+        // when
+        dependencies.init();
+
+        // then
+        assertThat(dependencies.injectableByField()).isEmpty();
+    }
 
     @Test
     public void resolveTypeParameters_should_return_an_empty_list_when_there_are_no_type_parameters() throws Exception

--- a/org.moreunit.mock/src/org/moreunit/mock/dependencies/Dependencies.java
+++ b/org.moreunit.mock/src/org/moreunit/mock/dependencies/Dependencies.java
@@ -72,7 +72,7 @@ public class Dependencies extends ArrayList<Dependency>
             for (int i = 0; i < parameterNames.length; i++)
             {
                 Dependency dependency = createConstructorDependency(parameterTypes[i], parameterNames[i]);
-                if(! contains(dependency))
+                if(dependency != null && ! contains(dependency))
                 {
                     constructorDependencies.add(dependency);
                     add(dependency);
@@ -83,6 +83,10 @@ public class Dependencies extends ArrayList<Dependency>
 
     private Dependency createConstructorDependency(String parameterType, String parameterName) throws JavaModelException
     {
+        if (Signature.getArrayCount(parameterType) > 0)
+        {
+            return null;
+        }
         String signature = Signature.toString(parameterType);
         String dependencyName = namingRules.cleanParameterName(parameterName);
         return new Dependency(resolveTypeSignature(signature), dependencyName, resolveTypeParameters(signature));
@@ -93,7 +97,7 @@ public class Dependencies extends ArrayList<Dependency>
         for (IMethod method : injectionPointProvider.getSetters())
         {
             SetterDependency dependency = createSetterDependency(method);
-            if(! contains(dependency))
+            if(dependency != null && ! contains(dependency))
             {
                 setterDependencies.add(dependency);
                 add(dependency);
@@ -103,7 +107,12 @@ public class Dependencies extends ArrayList<Dependency>
 
     private SetterDependency createSetterDependency(IMethod method) throws JavaModelException
     {
-        String signature = Signature.toString(method.getParameterTypes()[0]);
+        String parameterType = method.getParameterTypes()[0];
+        if (Signature.getArrayCount(parameterType) > 0)
+        {
+            return null;
+        }
+        String signature = Signature.toString(parameterType);
         return new SetterDependency(resolveTypeSignature(signature), method.getElementName(), resolveTypeParameters(signature));
     }
 
@@ -131,7 +140,7 @@ public class Dependencies extends ArrayList<Dependency>
         for (IField field : injectionPointProvider.getFields())
         {
             FieldDependency dependency = createFieldDependency(field);
-            if(! contains(dependency))
+            if(dependency != null && ! contains(dependency))
             {
                 fieldDependencies.add(dependency);
                 add(dependency);
@@ -141,7 +150,12 @@ public class Dependencies extends ArrayList<Dependency>
 
     private FieldDependency createFieldDependency(IField field) throws JavaModelException
     {
-        String signature = Signature.toString(field.getTypeSignature());
+        String typeSignature = field.getTypeSignature();
+        if (Signature.getArrayCount(typeSignature) > 0)
+        {
+            return null;
+        }
+        String signature = Signature.toString(typeSignature);
         String fieldName = field.getElementName();
         String dependencyName = namingRules.cleanFieldName(fieldName);
         return new FieldDependency(resolveTypeSignature(signature), fieldName, dependencyName, resolveTypeParameters(signature));

--- a/run_test2.sh
+++ b/run_test2.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+xvfb-run mvn -f org.moreunit.build/pom.xml test -pl org.moreunit.plugins:org.moreunit.mock.test


### PR DESCRIPTION
Array types like `String[]` should not be considered mockable dependencies.
Updated `Dependencies` resolution logic to use `Signature.getArrayCount()`
to identify array types in constructors, fields, and setters, and skip
them when building the dependency list.

Added `should_ignore_array_types` to `DependenciesTest` to verify.

---
*PR created automatically by Jules for task [9389838677659889251](https://jules.google.com/task/9389838677659889251) started by @RoiSoleil*