### PR TITLE
🧪 [MockingTemplateLoader] Add test for TemplateAlreadyDefinedException

### DIFF
--- a/org.moreunit.mock.test/test/org/moreunit/mock/templates/MockingTemplateLoaderTest.java
+++ b/org.moreunit.mock.test/test/org/moreunit/mock/templates/MockingTemplateLoaderTest.java
@@ -152,6 +152,30 @@ public class MockingTemplateLoaderTest
                           entry(existingDefinition2Url, "A template is already defined with this ID"));
     }
 
+    @Test
+    public void should_log_error_when_template_already_defined() throws Exception
+    {
+        // given
+        URL definitionUrl = URI.create("file:/already.defined.url").toURL();
+        when(resourceLoader.findBundleResources(eq(TEMPLATE_DIRECTORY), anyString())).thenReturn(singleton(definitionUrl));
+        when(resourceLoader.findWorkspaceStateResources(anyString(), anyString())).thenReturn(noResources);
+
+        TemplateAlreadyDefinedException exception = new TemplateAlreadyDefinedException("templateId");
+        when(templateDefinitionReader.read(definitionUrl)).thenReturn(someTemplates);
+        doThrow(exception).when(templateStore).store(someTemplates);
+
+        // when
+        LoadingResult result = loader.loadTemplates();
+
+        // then
+        verify(logger).error("Could not load template " + definitionUrl, exception);
+
+        assertThat(result.invalidTemplatesFound()).isTrue();
+        assertThat(result.invalidTemplates()).hasSize(1)
+                .contains(entry(definitionUrl, "A template is already defined with this ID"));
+
+    }
+
     private MockingTemplates someTemplates()
     {
         return new MockingTemplates(new ArrayList<Category>(), asList(new MockingTemplate("template")));


### PR DESCRIPTION
🎯 **What:** Added missing test to MockingTemplateLoaderTest.java to cover the path where TemplateAlreadyDefinedException is caught and added to the invalid templates results.
📊 **Coverage:** MockingTemplateLoader.java line 69 is now tested.
✨ **Result:** Improved test coverage for MockingTemplateLoader error path.

---
*PR created automatically by Jules for task [8253897027526835219](https://jules.google.com/task/8253897027526835219) started by @RoiSoleil*