### PR TITLE
Fix Dependabot directory configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
 - package-ecosystem: maven
-  directory: /
+  directory: /org.moreunit.build
   schedule:
     interval: daily
   open-pull-requests-limit: 10


### PR DESCRIPTION
Fix Dependabot directory configuration

Dependabot was failing to find the Maven `pom.xml` because it was configured to look in the root directory `/`. The root `pom.xml` was moved to `org.moreunit.build/pom.xml` previously.

This commit updates `.github/dependabot.yml` to set the `directory` to `/org.moreunit.build` for the `maven` ecosystem so that Dependabot can successfully analyze and update Maven dependencies again.

---
*PR created automatically by Jules for task [1477071162828246707](https://jules.google.com/task/1477071162828246707) started by @RoiSoleil*