### PR TITLE
ci: Add PMD and CPD checks to Maven build workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Build and verify
         run: mvn -file org.moreunit.build/pom.xml clean install "-Dtarget.platform.classifier=eclipse-latest" --fail-at-end --batch-mode --strict-checksums --update-snapshots "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
 
+      - name: Run PMD and CPD checks
+        run: mvn -file org.moreunit.build/pom.xml pmd:check pmd:cpd-check
+
       - name: Publish Surefire Test Results for  🖨
         if: ${{ always() }}
         uses: ScaCap/action-surefire-report@v1

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![MoreUnit Build](https://github.com/MoreUnit/MoreUnit-Eclipse/actions/workflows/maven.yml/badge.svg)](https://github.com/MoreUnit/MoreUnit-Eclipse/actions/workflows/maven.yml)
 [![CodeQL](https://github.com/MoreUnit/MoreUnit-Eclipse/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/MoreUnit/MoreUnit-Eclipse/actions/workflows/codeql-analysis.yml)
 [![codecov](https://codecov.io/gh/MoreUnit/MoreUnit-Eclipse/branch/master/graph/badge.svg)](https://codecov.io/gh/MoreUnit/MoreUnit-Eclipse)
 


### PR DESCRIPTION
Adds PMD and CPD static analysis checks to the GitHub Actions `maven.yml` workflow and updates the README to display the workflow badge.

---
*PR created automatically by Jules for task [1276871137883998607](https://jules.google.com/task/1276871137883998607) started by @RoiSoleil*