### PR TITLE
test: improve coverage for Strings utility class

### DIFF
--- a/org.moreunit.core.test/test/org/moreunit/core/util/StringsTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/util/StringsTest.java
@@ -84,6 +84,16 @@ public class StringsTest
     }
 
     @Test
+    public void should_return_zero_when_count_occurrences_is_called_with_empty_strings() throws Exception
+    {
+        assertThat(Strings.countOccurrences("", "test")).isEqualTo(0);
+        assertThat(Strings.countOccurrences(null, "test")).isEqualTo(0);
+        assertThat(Strings.countOccurrences("test", "")).isEqualTo(0);
+        assertThat(Strings.countOccurrences("test", null)).isEqualTo(0);
+        assertThat(Strings.countOccurrences(null, null)).isEqualTo(0);
+    }
+
+    @Test
     public void split_should_ignore_blank_parts() throws Exception
     {
         assertThat(Strings.split(",a4,,b,   ,cD, ", ",")).isEqualTo(new String[] { "a4", "b", "cD" });
@@ -126,6 +136,22 @@ public class StringsTest
     {
         assertThat(Strings.join(",", "1", "2", "3")).isEqualTo("1,2,3");
         assertThat(Strings.join(" -> ", "aBc", "2", "DEf")).isEqualTo("aBc -> 2 -> DEf");
+    }
+
+    @Test
+    public void join_should_append_to_string_builder_with_given_separator_for_collection() throws Exception
+    {
+        StringBuilder sb = new StringBuilder("prefix: ");
+        Strings.join(sb, ",", java.util.Arrays.asList("1", "2", "3"));
+        assertThat(sb.toString()).isEqualTo("prefix: 1,2,3");
+    }
+
+    @Test
+    public void join_should_append_to_string_builder_with_given_separator_for_array() throws Exception
+    {
+        StringBuilder sb = new StringBuilder("prefix: ");
+        Strings.join(sb, " -> ", new String[]{"aBc", "2", "DEf"});
+        assertThat(sb.toString()).isEqualTo("prefix: aBc -> 2 -> DEf");
     }
 
     @Test


### PR DESCRIPTION
J'ai amélioré la couverture de tests pour la classe utilitaire `Strings` dans le module `org.moreunit.core.test`.

- Ajout de tests pour les méthodes `join` utilisant `StringBuilder` (tableaux et collections).
- Ajout de tests pour les cas aux limites (chaînes vides ou nulles) de `countOccurrences`.
- Ces ajouts n'altèrent en rien le comportement de production et évitent d'introduire des tests instables liés à l'interface utilisateur.

---
*PR created automatically by Jules for task [18221104773447823059](https://jules.google.com/task/18221104773447823059) started by @RoiSoleil*