### PR TITLE
test: improve coverage for org.moreunit.core.resources.InMemory* classes

### DIFF
--- a/org.moreunit.core.test/test/org/moreunit/core/resources/InMemoryFileTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/resources/InMemoryFileTest.java
@@ -1,0 +1,61 @@
+package org.moreunit.core.resources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class InMemoryFileTest {
+
+    @Test
+    public void testGetBaseNameWithoutExtension() {
+        InMemoryWorkspace workspace = new InMemoryWorkspace();
+        InMemoryFile file = workspace.getProject("project").getFile("folder/file.txt");
+        assertThat(file.getBaseNameWithoutExtension()).isEqualTo("file");
+
+        InMemoryFile fileNoExt = workspace.getProject("project").getFile("folder/file");
+        assertThat(fileNoExt.getBaseNameWithoutExtension()).isEqualTo("file");
+    }
+
+    @Test
+    public void testGetExtension() {
+        InMemoryWorkspace workspace = new InMemoryWorkspace();
+        InMemoryFile file = workspace.getProject("project").getFile("folder/file.txt");
+        assertThat(file.getExtension()).isEqualTo("txt");
+
+        InMemoryFile fileNoExt = workspace.getProject("project").getFile("folder/file");
+        assertThat(fileNoExt.getExtension()).isEqualTo("");
+    }
+
+    @Test
+    public void testHasExtension() {
+        InMemoryWorkspace workspace = new InMemoryWorkspace();
+        InMemoryFile file = workspace.getProject("project").getFile("folder/file.txt");
+        assertThat(file.hasExtension()).isTrue();
+
+        InMemoryFile fileNoExt = workspace.getProject("project").getFile("folder/file");
+        assertThat(fileNoExt.hasExtension()).isFalse();
+    }
+
+    @Test
+    public void testGetProject() {
+        InMemoryWorkspace workspace = new InMemoryWorkspace();
+        InMemoryProject project = workspace.getProject("project");
+        InMemoryFile file = project.getFile("folder/file.txt");
+
+        assertThat(file.getProject()).isSameAs(project);
+    }
+
+    @Test
+    public void testGetProjectPreferences() {
+        InMemoryWorkspace workspace = new InMemoryWorkspace();
+        InMemoryFile file = workspace.getProject("project").getFile("folder/file.txt");
+        assertThat(file.getProjectPreferences()).isNull();
+    }
+
+    @Test
+    public void testGetUnderlyingPlatformFile() {
+        InMemoryWorkspace workspace = new InMemoryWorkspace();
+        InMemoryFile file = workspace.getProject("project").getFile("folder/file.txt");
+        assertThat(file.getUnderlyingPlatformFile()).isNull();
+    }
+}

--- a/org.moreunit.core.test/test/org/moreunit/core/resources/InMemoryFolderTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/resources/InMemoryFolderTest.java
@@ -1,0 +1,26 @@
+package org.moreunit.core.resources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class InMemoryFolderTest {
+
+    @Test
+    public void testGetProject() {
+        InMemoryWorkspace workspace = new InMemoryWorkspace();
+        InMemoryProject project = workspace.getProject("project");
+        InMemoryFolder folder = project.getFolder("folder/subfolder");
+
+        assertThat(folder.getProject()).isSameAs(project);
+    }
+
+    @Test
+    public void testGetProjectPreferences() {
+        InMemoryWorkspace workspace = new InMemoryWorkspace();
+        InMemoryProject project = workspace.getProject("project");
+        InMemoryFolder folder = project.getFolder("folder/subfolder");
+
+        assertThat(folder.getProjectPreferences()).isNull();
+    }
+}

--- a/org.moreunit.core.test/test/org/moreunit/core/resources/InMemoryPathTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/resources/InMemoryPathTest.java
@@ -1,0 +1,129 @@
+package org.moreunit.core.resources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+import java.util.Iterator;
+
+import org.junit.Test;
+
+public class InMemoryPathTest {
+
+    @Test
+    public void testGetBaseNameWithoutExtension() {
+        InMemoryPath path = new InMemoryPath("/project/folder/file.txt");
+        assertThat(path.getBaseNameWithoutExtension()).isEqualTo("file");
+
+        InMemoryPath pathNoExt = new InMemoryPath("/project/folder/file");
+        assertThat(pathNoExt.getBaseNameWithoutExtension()).isEqualTo("file");
+
+        InMemoryPath emptyPath = new InMemoryPath("");
+        assertThat(emptyPath.getBaseNameWithoutExtension()).isEqualTo("");
+    }
+
+    @Test
+    public void testGetExtension() {
+        InMemoryPath path = new InMemoryPath("/project/folder/file.txt");
+        assertThat(path.getExtension()).isEqualTo("txt");
+
+        InMemoryPath pathNoExt = new InMemoryPath("/project/folder/file");
+        assertThat(pathNoExt.getExtension()).isEqualTo("");
+
+        InMemoryPath emptyPath = new InMemoryPath("");
+        assertThat(emptyPath.getExtension()).isEqualTo("");
+    }
+
+    @Test
+    public void testGetProjectName() {
+        InMemoryPath path = new InMemoryPath("/project/folder/file.txt");
+        assertThat(path.getProjectName()).isEqualTo("project");
+
+        InMemoryPath emptyPath = new InMemoryPath("");
+        assertThat(emptyPath.getProjectName()).isEqualTo("");
+    }
+
+    @Test
+    public void testHasExtension() {
+        InMemoryPath path = new InMemoryPath("/project/folder/file.txt");
+        assertThat(path.hasExtension()).isTrue();
+
+        InMemoryPath pathNoExt = new InMemoryPath("/project/folder/file");
+        assertThat(pathNoExt.hasExtension()).isFalse();
+    }
+
+    @Test
+    public void testIterator() {
+        InMemoryPath path = new InMemoryPath("/project/folder/file.txt");
+        Iterator<String> iterator = path.iterator();
+        assertThat(iterator.hasNext()).isTrue();
+        assertThat(iterator.next()).isEqualTo("project");
+        assertThat(iterator.next()).isEqualTo("folder");
+        assertThat(iterator.next()).isEqualTo("file.txt");
+        assertThat(iterator.hasNext()).isFalse();
+    }
+
+    @Test
+    public void testRelativeToProject() {
+        InMemoryPath path = new InMemoryPath("/project/folder/file.txt");
+        assertThat(path.relativeToProject().toString()).isEqualTo("folder/file.txt");
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        InMemoryPath path1 = new InMemoryPath("/project/folder/file.txt");
+        InMemoryPath path2 = new InMemoryPath("/project/folder/file.txt");
+        InMemoryPath path3 = new InMemoryPath("/project/folder/other.txt");
+
+        assertThat(path1).isEqualTo(path2);
+        assertThat(path1).isNotEqualTo(path3);
+        assertThat(path1).isNotEqualTo(null);
+        assertThat(path1).isNotEqualTo(new Object());
+        assertThat(path1).isEqualTo(path1);
+
+        assertThat(path1.hashCode()).isEqualTo(path2.hashCode());
+        assertThat(path1.hashCode()).isNotEqualTo(path3.hashCode());
+    }
+
+    @Test
+    public void testWithoutLastSegment() {
+        InMemoryPath path = new InMemoryPath("/project/folder/file.txt");
+        assertThat(path.withoutLastSegment().toString()).isEqualTo("/project/folder");
+
+        InMemoryPath pathRoot = new InMemoryPath("/project");
+        assertThat(pathRoot.withoutLastSegment().toString()).isEqualTo("/");
+
+        InMemoryPath emptyPath = new InMemoryPath("");
+        assertThat(emptyPath.withoutLastSegment().toString()).isEqualTo("");
+    }
+
+    @Test
+    public void testUptoSegment() {
+        InMemoryPath path = new InMemoryPath("/project/folder/file.txt");
+        assertThat(path.uptoSegment(1).toString()).isEqualTo("/project");
+        assertThat(path.uptoSegment(2).toString()).isEqualTo("/project/folder");
+        assertThat(path.uptoSegment(3).toString()).isEqualTo("/project/folder/file.txt");
+
+        try {
+            path.uptoSegment(4);
+            fail("Expected IndexOutOfBoundsException");
+        } catch (IndexOutOfBoundsException e) {
+            assertThat(e.getMessage()).isEqualTo("No segment at index: 4");
+        }
+    }
+
+    @Test
+    public void testWithRelativePath() {
+        InMemoryPath path = new InMemoryPath("/project/folder");
+        InMemoryPath relativePath = new InMemoryPath("file.txt");
+
+        assertThat(path.withRelativePath(relativePath).toString()).isEqualTo("/project/folder/file.txt");
+
+        InMemoryPath absolutePath = new InMemoryPath("/file.txt");
+        try {
+            path.withRelativePath(absolutePath);
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage()).isEqualTo("not a relative path");
+        }
+    }
+}

--- a/org.moreunit.core.test/test/org/moreunit/core/resources/InMemoryProjectTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/resources/InMemoryProjectTest.java
@@ -1,0 +1,20 @@
+package org.moreunit.core.resources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class InMemoryProjectTest {
+
+    @Test
+    public void testAddToParentAndGetName() {
+        InMemoryWorkspace workspace = new InMemoryWorkspace();
+        InMemoryProject project = new InMemoryProject("my-project", workspace);
+
+        assertThat(project.getName()).isEqualTo("my-project");
+        assertThat(project.getParent()).isSameAs(workspace);
+
+        // Ensure it's in the workspace's projects map
+        assertThat(workspace.getProject("my-project")).isSameAs(project);
+    }
+}

--- a/org.moreunit.core.test/test/org/moreunit/core/resources/InMemoryResourceTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/resources/InMemoryResourceTest.java
@@ -1,0 +1,72 @@
+package org.moreunit.core.resources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class InMemoryResourceTest {
+
+    @Test
+    public void testEqualsAndHashCode() {
+        InMemoryWorkspace workspace = new InMemoryWorkspace();
+        InMemoryFile file1 = workspace.getProject("project").getFile("folder/file.txt");
+        InMemoryFile file2 = workspace.getProject("project").getFile("folder/file.txt");
+        InMemoryFile file3 = workspace.getProject("project").getFile("folder/other.txt");
+
+        assertThat(file1).isEqualTo(file2);
+        assertThat(file1).isNotEqualTo(file3);
+        assertThat(file1).isNotEqualTo(null);
+        assertThat(file1).isNotEqualTo(new Object());
+        assertThat(file1).isEqualTo(file1);
+
+        assertThat(file1.hashCode()).isEqualTo(file2.hashCode());
+        assertThat(file1.hashCode()).isNotEqualTo(file3.hashCode());
+    }
+
+    @Test
+    public void testToString() {
+        InMemoryWorkspace workspace = new InMemoryWorkspace();
+        InMemoryFile file = workspace.getProject("project").getFile("folder/file.txt");
+        assertThat(file.toString()).isEqualTo("/project/folder/file.txt");
+    }
+
+    @Test
+    public void testGetUnderlyingPlatformResource() {
+        InMemoryWorkspace workspace = new InMemoryWorkspace();
+        InMemoryFile file = workspace.getProject("project").getFile("folder/file.txt");
+        assertThat(file.getUnderlyingPlatformResource()).isNull();
+    }
+
+    @Test
+    public void testExistsCreateDelete() {
+        InMemoryWorkspace workspace = new InMemoryWorkspace();
+        InMemoryFile file = workspace.getProject("project").getFile("folder/file.txt");
+
+        assertThat(file.exists()).isFalse();
+
+        file.create();
+        assertThat(file.exists()).isTrue();
+
+        file.delete();
+        assertThat(file.exists()).isFalse();
+    }
+
+    @Test
+    public void testGetName() {
+        InMemoryWorkspace workspace = new InMemoryWorkspace();
+        InMemoryFile file = workspace.getProject("project").getFile("folder/file.txt");
+        assertThat(file.getName()).isEqualTo("file.txt");
+    }
+
+    @Test
+    public void testGetPathAndParent() {
+        InMemoryWorkspace workspace = new InMemoryWorkspace();
+        InMemoryProject project = workspace.getProject("project");
+        InMemoryFolder folder = project.getFolder("folder");
+        InMemoryFile file = folder.getFile("file.txt");
+
+        assertThat(file.getPath().toString()).isEqualTo("/project/folder/file.txt");
+        assertThat(file.getParent()).isSameAs(folder);
+        assertThat(folder.getParent()).isSameAs(project);
+    }
+}

--- a/org.moreunit.core.test/test/org/moreunit/core/resources/InMemoryWorkspaceTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/resources/InMemoryWorkspaceTest.java
@@ -1,0 +1,65 @@
+package org.moreunit.core.resources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.IPath;
+import org.junit.Test;
+
+public class InMemoryWorkspaceTest {
+
+    @Test
+    public void testCreateDeleteExists() {
+        InMemoryWorkspace workspace = new InMemoryWorkspace();
+
+        // Exists is always true
+        assertThat(workspace.exists()).isTrue();
+
+        // These don't change exists status
+        workspace.create();
+        assertThat(workspace.exists()).isTrue();
+
+        workspace.delete();
+        assertThat(workspace.exists()).isTrue();
+    }
+
+    @Test
+    public void testGetPreferences() {
+        InMemoryWorkspace workspace = new InMemoryWorkspace();
+        assertThat(workspace.getPreferences()).isNull();
+    }
+
+    @Test
+    public void testToFile() {
+        InMemoryWorkspace workspace = new InMemoryWorkspace();
+
+        IPath mockPath = mock(IPath.class);
+        when(mockPath.toString()).thenReturn("/project/folder/file.txt");
+
+        IFile mockPlatformFile = mock(IFile.class);
+        when(mockPlatformFile.getFullPath()).thenReturn(mockPath);
+
+        File file = workspace.toFile(mockPlatformFile);
+
+        assertThat(file).isNotNull();
+        assertThat(file.getPath().toString()).isEqualTo("/project/folder/file.txt");
+    }
+
+    @Test
+    public void testToSrcFile() {
+        InMemoryWorkspace workspace = new InMemoryWorkspace();
+
+        IPath mockPath = mock(IPath.class);
+        when(mockPath.toString()).thenReturn("/project/folder/file.txt");
+
+        IFile mockPlatformFile = mock(IFile.class);
+        when(mockPlatformFile.getFullPath()).thenReturn(mockPath);
+
+        SrcFile srcFile = workspace.toSrcFile(mockPlatformFile);
+
+        assertThat(srcFile).isNotNull();
+        assertThat(srcFile.getPath().toString()).isEqualTo("/project/folder/file.txt");
+    }
+}


### PR DESCRIPTION
This PR adds dedicated test suites for the previously under-tested `InMemory*` mock resource classes used across the testing module (`org.moreunit.core.test`).

To fulfill the user's latest constraints:
- All new tests strictly adhere to JUnit 4 (`@Test` from `org.junit`).
- `assertThrows` refactors originally planned using JUnit 5 were reverted to keep the codebase pure JUnit 4.
- Handled UI verification and Mockito injection cleanly.

---
*PR created automatically by Jules for task [5009297892805505733](https://jules.google.com/task/5009297892805505733) started by @RoiSoleil*