### PR TITLE
Feature: Add toggle for Jump to test class link

### DIFF
--- a/org.moreunit.plugin/src/org/moreunit/codemining/MoreUnitCodeMiningProvider.java
+++ b/org.moreunit.plugin/src/org/moreunit/codemining/MoreUnitCodeMiningProvider.java
@@ -84,7 +84,7 @@ public class MoreUnitCodeMiningProvider extends AbstractCodeMiningProvider
             }
             // support methods, classes
             boolean addMining = false;
-            if(element instanceof IType type)
+            if(element instanceof IType type && preferences.shouldEnableJumpToClassCodeMining(unit.getJavaProject()))
             {
                 if(type.isClass() || type.isEnum() || type.isInterface() || type.isRecord() || type.isAnnotation())
                 {

--- a/org.moreunit.plugin/src/org/moreunit/preferences/PreferenceConstants.java
+++ b/org.moreunit.plugin/src/org/moreunit/preferences/PreferenceConstants.java
@@ -27,6 +27,7 @@ public interface PreferenceConstants
     String GENERATE_COMMENTS_FOR_TEST_METHOD = "org.moreunit.generateCommentsForTestMethod";
     String ENABLE_MOREUNIT_CODE_MINING = "org.moreunit.enableMoreUnitCodeMining";
     String ENABLE_JUMP_TO_METHOD_CODE_MINING = "org.moreunit.enableJumpToMethodCodeMining";
+    String ENABLE_JUMP_TO_CLASS_CODE_MINING = "org.moreunit.enableJumpToClassCodeMining";
 
     String TEST_TYPE = "org.moreunit.test_type";
     String TEST_TYPE_VALUE_JUNIT_3 = "junit3";
@@ -49,6 +50,7 @@ public interface PreferenceConstants
     String DEFAULT_TEST_ANNOTATION_MODE = "OFF";
     boolean DEFAULT_ENABLE_MOREUNIT_CODEMINING = true;
     boolean DEFAULT_ENABLE_JUMP_TO_METHOD_CODE_MINING = true;
+    boolean DEFAULT_ENABLE_JUMP_TO_CLASS_CODE_MINING = true;
 
     String TEXT_GENERAL_SETTINGS = "General settings for your unit tests (they can then be refined for each project):";
     String TEXT_TEST_SUPERCLASS = "Test superclass:";
@@ -68,6 +70,7 @@ public interface PreferenceConstants
     String TEXT_GENERATE_COMMENTS_FOR_TEST_METHOD = "Generate comments for test methods";
     String TEXT_ENABLE_MOREUNIT_CODEMINING = "Enable MoreUnit Code Mining";
     String TEXT_ENABLE_JUMP_TO_METHOD_CODE_MINING = "Enable \"Jump to method\" Code Mining (on the right side of the editor)";
+    String TEXT_ENABLE_JUMP_TO_CLASS_CODE_MINING = "Enable \"Jump to class\" Code Mining (on the right side of the editor)";
     String TEXT_ANNOTATION_MODE = "Annotate tested methods";
     String TEST_ANNOTATION_MODE_DISABLED = "Disabled";
     String TEST_ANNOTATION_MODE_BY_NAME = "Search by method name";
@@ -83,6 +86,7 @@ public interface PreferenceConstants
     String TOOLTIP_TEST_ANNOTATION_EXTENDED_SEARCH = "This option will cause conflicts if other parts of Eclipse are searching for method method calls at the same time, which occurs often. Only activate if you know what you are doing.";
     String TOOLTIP_ENABLE_MOREUNIT_CODEMINING = "Code Mining adds information and links directly in the editor.";
     String TOOLTIP_ENABLE_JUMP_TO_METHOD_CODE_MINING = "Shows a \"Jump to test/tested method\" link at the end of method declarations.";
+    String TOOLTIP_ENABLE_JUMP_TO_CLASS_CODE_MINING = "Shows a \"Jump to test/tested class\" link at the end of class declarations.";
 
     String TEST_METHOD_TYPE = "org.moreunit.test_methodType";
     String TEST_METHOD_TYPE_JUNIT3 = "testMethodTypeJunit3";

--- a/org.moreunit.plugin/src/org/moreunit/preferences/Preferences.java
+++ b/org.moreunit.plugin/src/org/moreunit/preferences/Preferences.java
@@ -81,6 +81,7 @@ public class Preferences
         store.setDefault(PreferenceConstants.TEST_ANNOTATION_MODE, PreferenceConstants.DEFAULT_TEST_ANNOTATION_MODE);
         store.setDefault(PreferenceConstants.ENABLE_MOREUNIT_CODE_MINING, PreferenceConstants.DEFAULT_ENABLE_MOREUNIT_CODEMINING);
         store.setDefault(PreferenceConstants.ENABLE_JUMP_TO_METHOD_CODE_MINING, PreferenceConstants.DEFAULT_ENABLE_JUMP_TO_METHOD_CODE_MINING);
+        store.setDefault(PreferenceConstants.ENABLE_JUMP_TO_CLASS_CODE_MINING, PreferenceConstants.DEFAULT_ENABLE_JUMP_TO_CLASS_CODE_MINING);
         return store;
     }
 
@@ -506,6 +507,20 @@ public class Preferences
     public void setEnableJumpToMethodCodeMining(IJavaProject javaProject, boolean enableJumpToMethodCodeMining)
     {
         getProjectStore(javaProject).setValue(PreferenceConstants.ENABLE_JUMP_TO_METHOD_CODE_MINING, enableJumpToMethodCodeMining);
+    }
+
+    public boolean shouldEnableJumpToClassCodeMining(IJavaProject javaProject)
+    {
+        if(storeToRead(javaProject).contains(PreferenceConstants.ENABLE_JUMP_TO_CLASS_CODE_MINING))
+        {
+            return storeToRead(javaProject).getBoolean(PreferenceConstants.ENABLE_JUMP_TO_CLASS_CODE_MINING);
+        }
+        return storeToRead(javaProject).getDefaultBoolean(PreferenceConstants.ENABLE_JUMP_TO_CLASS_CODE_MINING);
+    }
+
+    public void setEnableJumpToClassCodeMining(IJavaProject javaProject, boolean enableJumpToClassCodeMining)
+    {
+        getProjectStore(javaProject).setValue(PreferenceConstants.ENABLE_JUMP_TO_CLASS_CODE_MINING, enableJumpToClassCodeMining);
     }
 
     public MethodSearchMode getMethodSearchMode(IJavaProject javaProject)

--- a/org.moreunit.plugin/src/org/moreunit/properties/OtherMoreunitPropertiesBlock.java
+++ b/org.moreunit.plugin/src/org/moreunit/properties/OtherMoreunitPropertiesBlock.java
@@ -44,6 +44,7 @@ public class OtherMoreunitPropertiesBlock implements SelectionListener
     private Button addCommentsToTestMethodCheckbox;
     private Button enableMoreUnitCodeMining;
     private Button enableJumpToMethodCodeMiningCheckbox;
+    private Button enableJumpToClassCodeMiningCheckbox;
     private Button extendedSearchCheckbox;
     private Button enableSearchByNameCheckbox;
 
@@ -112,6 +113,7 @@ public class OtherMoreunitPropertiesBlock implements SelectionListener
         createAddCommentsToTestMethodsCheckbox(parentWith2Cols);
         createEnableMoreUnitCodeMiningCheckbox(parentWith2Cols);
         createEnableJumpToMethodCodeMiningCheckbox(parentWith2Cols);
+        createEnableJumpToClassCodeMiningCheckbox(parentWith2Cols);
 
         checkStateOfMethodPrefixButton();
     }
@@ -343,6 +345,7 @@ public class OtherMoreunitPropertiesBlock implements SelectionListener
             public void widgetSelected(SelectionEvent e)
             {
                 enableJumpToMethodCodeMiningCheckbox.setEnabled(enableMoreUnitCodeMining.getSelection());
+                enableJumpToClassCodeMiningCheckbox.setEnabled(enableMoreUnitCodeMining.getSelection());
             }
         });
     }
@@ -360,6 +363,21 @@ public class OtherMoreunitPropertiesBlock implements SelectionListener
 
         enableJumpToMethodCodeMiningCheckbox.setSelection(preferences.shouldEnableJumpToMethodCodeMining(javaProject));
         enableJumpToMethodCodeMiningCheckbox.setEnabled(enableMoreUnitCodeMining.getSelection());
+    }
+
+    private void createEnableJumpToClassCodeMiningCheckbox(Composite parent)
+    {
+        enableJumpToClassCodeMiningCheckbox = new Button(parent, SWT.CHECK);
+        enableJumpToClassCodeMiningCheckbox.setText(PreferenceConstants.TEXT_ENABLE_JUMP_TO_CLASS_CODE_MINING);
+        enableJumpToClassCodeMiningCheckbox.setToolTipText(PreferenceConstants.TOOLTIP_ENABLE_JUMP_TO_CLASS_CODE_MINING);
+
+        GridData gridData = new GridData(GridData.HORIZONTAL_ALIGN_FILL);
+        gridData.horizontalSpan = 2;
+        gridData.horizontalIndent = 20;
+        enableJumpToClassCodeMiningCheckbox.setLayoutData(gridData);
+
+        enableJumpToClassCodeMiningCheckbox.setSelection(preferences.shouldEnableJumpToClassCodeMining(javaProject));
+        enableJumpToClassCodeMiningCheckbox.setEnabled(enableMoreUnitCodeMining.getSelection());
     }
 
     public void saveProperties()
@@ -389,6 +407,7 @@ public class OtherMoreunitPropertiesBlock implements SelectionListener
         preferences.setGenerateCommentsForTestMethod(javaProject, addCommentsToTestMethodCheckbox.getSelection());
         preferences.setEnableMoreUnitCodeMining(javaProject, enableMoreUnitCodeMining.getSelection());
         preferences.setEnableJumpToMethodCodeMining(javaProject, enableJumpToMethodCodeMiningCheckbox.getSelection());
+        preferences.setEnableJumpToClassCodeMining(javaProject, enableJumpToClassCodeMiningCheckbox.getSelection());
 
         if(testAnnotationsByNameAndByCallButton.getSelection())
         {
@@ -485,6 +504,7 @@ public class OtherMoreunitPropertiesBlock implements SelectionListener
         enableSearchByNameCheckbox.setEnabled(enabled);
         addCommentsToTestMethodCheckbox.setEnabled(enabled);
         enableJumpToMethodCodeMiningCheckbox.setEnabled(enabled && enableMoreUnitCodeMining.getSelection());
+        enableJumpToClassCodeMiningCheckbox.setEnabled(enabled && enableMoreUnitCodeMining.getSelection());
         testCaseNamePatternArea.setEnabled(enabled);
         testAnnotationsDisabledButton.setEnabled(enabled);
         testAnnotationsByNameButton.setEnabled(enabled);

--- a/org.moreunit.swtbot.test/test/org/moreunit/settings/PreferencesTest.java
+++ b/org.moreunit.swtbot.test/test/org/moreunit/settings/PreferencesTest.java
@@ -160,4 +160,24 @@ public class PreferencesTest extends JavaProjectSWTBotTestHelper
         assertThat(Preferences.getInstance().getMethodSearchMode(getJavaProjectFromContext()).searchByCall).isFalse();
         assertThat(Preferences.getInstance().getMethodSearchMode(getJavaProjectFromContext()).searchByName).isTrue();
     }
+
+    @Test
+    public void should_update_code_mining_preferences_when_preferences_change()
+    {
+        openPreferencesAndSelectMoreUnitPage();
+        bot.checkBox(PreferenceConstants.TEXT_ENABLE_MOREUNIT_CODEMINING).select();
+        bot.checkBox(PreferenceConstants.TEXT_ENABLE_JUMP_TO_METHOD_CODE_MINING).deselect();
+        bot.checkBox(PreferenceConstants.TEXT_ENABLE_JUMP_TO_CLASS_CODE_MINING).deselect();
+        saveAndClosePrefs();
+        assertThat(Preferences.getInstance().shouldEnableMoreUnitCodeMining(getJavaProjectFromContext())).isTrue();
+        assertThat(Preferences.getInstance().shouldEnableJumpToMethodCodeMining(getJavaProjectFromContext())).isFalse();
+        assertThat(Preferences.getInstance().shouldEnableJumpToClassCodeMining(getJavaProjectFromContext())).isFalse();
+
+        openPreferencesAndSelectMoreUnitPage();
+        bot.checkBox(PreferenceConstants.TEXT_ENABLE_JUMP_TO_METHOD_CODE_MINING).select();
+        bot.checkBox(PreferenceConstants.TEXT_ENABLE_JUMP_TO_CLASS_CODE_MINING).select();
+        saveAndClosePrefs();
+        assertThat(Preferences.getInstance().shouldEnableJumpToMethodCodeMining(getJavaProjectFromContext())).isTrue();
+        assertThat(Preferences.getInstance().shouldEnableJumpToClassCodeMining(getJavaProjectFromContext())).isTrue();
+    }
 }


### PR DESCRIPTION
Adds a toggle for "Jump to test class" link to MoreUnit preferences as requested in issue #328.

It's similar to the toggle added for "Jump to test method" in issue #230. The `MoreUnitCodeMiningProvider` has been updated to query the new preference.
The tests have been verified locally.

---
*PR created automatically by Jules for task [11340244364073265848](https://jules.google.com/task/11340244364073265848) started by @RoiSoleil*