### PR TITLE
test: improve coverage for core utility and matching classes

### DIFF
--- a/org.moreunit.core.test/src/org/moreunit/core/matching/SourceFolderPathTest.java
+++ b/org.moreunit.core.test/src/org/moreunit/core/matching/SourceFolderPathTest.java
@@ -1,0 +1,88 @@
+package org.moreunit.core.matching;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import org.eclipse.core.resources.IFile;
+import org.junit.jupiter.api.Test;
+import org.moreunit.core.resources.Folder;
+import org.moreunit.core.resources.Path;
+import org.moreunit.core.resources.Project;
+import org.moreunit.core.resources.Workspace;
+
+class SourceFolderPathTest {
+
+    @Test
+    void testIsResolved() {
+        Workspace workspace = mock(Workspace.class);
+        when(workspace.path("src/main/java")).thenReturn(new Path("src/main/java"));
+        when(workspace.path("src/*/java")).thenReturn(new Path("src/*/java"));
+
+        SourceFolderPath resolvedPath = new SourceFolderPath("src/main/java", workspace);
+        assertThat(resolvedPath.isResolved()).isTrue();
+
+        SourceFolderPath unresolvedPath = new SourceFolderPath("src/*/java", workspace);
+        assertThat(unresolvedPath.isResolved()).isFalse();
+    }
+
+    @Test
+    void testGetResolvedPart() {
+        Workspace workspace = mock(Workspace.class);
+        when(workspace.path("src/main/java")).thenReturn(new Path("src/main/java"));
+        when(workspace.path("src/*/java")).thenReturn(new Path("src/*/java"));
+        when(workspace.path("src/main/[^a-z]")).thenReturn(new Path("src/main/[^a-z]"));
+
+        SourceFolderPath resolvedPath = new SourceFolderPath("src/main/java", workspace);
+        assertThat(resolvedPath.getResolvedPart().toString()).isEqualTo("src/main/java");
+
+        SourceFolderPath unresolvedPath = new SourceFolderPath("src/*/java", workspace);
+        assertThat(unresolvedPath.getResolvedPart().toString()).isEqualTo("src");
+
+        SourceFolderPath unresolvedPath2 = new SourceFolderPath("src/main/[^a-z]", workspace);
+        assertThat(unresolvedPath2.getResolvedPart().toString()).isEqualTo("src/main");
+    }
+
+    @Test
+    void testGetResolvedPartAsResourceProject() {
+        Workspace workspace = mock(Workspace.class);
+        when(workspace.path("MyProject")).thenReturn(new Path("MyProject"));
+
+        Project mockProject = mock(Project.class);
+        when(workspace.getProject("MyProject")).thenReturn(mockProject);
+
+        SourceFolderPath path = new SourceFolderPath("MyProject", workspace);
+        assertThat(path.getResolvedPartAsResource()).isSameAs(mockProject);
+    }
+
+    @Test
+    void testGetResolvedPartAsResourceFolder() {
+        Workspace workspace = mock(Workspace.class);
+        when(workspace.path("MyProject/src")).thenReturn(new Path("MyProject/src"));
+
+        Folder mockFolder = mock(Folder.class);
+        when(workspace.getFolder(any(Path.class))).thenReturn(mockFolder);
+
+        SourceFolderPath path = new SourceFolderPath("MyProject/src", workspace);
+        assertThat(path.getResolvedPartAsResource()).isSameAs(mockFolder);
+    }
+
+    @Test
+    void testMatches() {
+        Workspace workspace = mock(Workspace.class);
+        when(workspace.path("MyProject/src/.*")).thenReturn(new Path("MyProject/src/.*"));
+
+        SourceFolderPath path = new SourceFolderPath("MyProject/src/.*", workspace);
+
+        IFile mockFile = mock(IFile.class);
+        org.eclipse.core.runtime.IPath mockPath = mock(org.eclipse.core.runtime.IPath.class);
+        org.eclipse.core.runtime.IPath mockRemovedPath = mock(org.eclipse.core.runtime.IPath.class);
+        org.eclipse.core.runtime.IPath mockFinalPath = mock(org.eclipse.core.runtime.IPath.class);
+
+        when(mockFile.getFullPath()).thenReturn(mockPath);
+        when(mockPath.removeLastSegments(1)).thenReturn(mockRemovedPath);
+        when(mockRemovedPath.removeTrailingSeparator()).thenReturn(mockFinalPath);
+        when(mockFinalPath.toString()).thenReturn("/MyProject/src/main");
+
+        assertThat(path.matches(mockFile)).isTrue();
+    }
+}

--- a/org.moreunit.core.test/src/org/moreunit/core/util/ArrayUtilsTest.java
+++ b/org.moreunit.core.test/src/org/moreunit/core/util/ArrayUtilsTest.java
@@ -1,0 +1,18 @@
+package org.moreunit.core.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+
+class ArrayUtilsTest {
+    @Test
+    void testArray() {
+        String[] result = ArrayUtils.array("a", "b", "c");
+        assertThat(result).containsExactly("a", "b", "c");
+    }
+
+    @Test
+    void testArrayEmpty() {
+        String[] result = ArrayUtils.array();
+        assertThat(result).isEmpty();
+    }
+}

--- a/org.moreunit.core.test/src/org/moreunit/core/util/IOUtilsTest.java
+++ b/org.moreunit.core.test/src/org/moreunit/core/util/IOUtilsTest.java
@@ -1,0 +1,47 @@
+package org.moreunit.core.util;
+
+import static org.mockito.Mockito.*;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+class IOUtilsTest {
+
+    @Test
+    void testCloseQuietlyWithNullArray() {
+        IOUtils.closeQuietly((Closeable[]) null);
+        // Should not throw an exception
+    }
+
+    @Test
+    void testCloseQuietlyWithNullElement() {
+        IOUtils.closeQuietly(new Closeable[] { null });
+        // Should not throw an exception
+    }
+
+    @Test
+    void testCloseQuietlySuccess() throws IOException {
+        Closeable mockCloseable1 = mock(Closeable.class);
+        Closeable mockCloseable2 = mock(Closeable.class);
+
+        IOUtils.closeQuietly(mockCloseable1, mockCloseable2);
+
+        verify(mockCloseable1).close();
+        verify(mockCloseable2).close();
+    }
+
+    @Test
+    void testCloseQuietlyWithException() throws IOException {
+        Closeable mockCloseable1 = mock(Closeable.class);
+        Closeable mockCloseable2 = mock(Closeable.class);
+
+        doThrow(new IOException("Test exception")).when(mockCloseable1).close();
+
+        IOUtils.closeQuietly(mockCloseable1, mockCloseable2);
+
+        verify(mockCloseable1).close();
+        verify(mockCloseable2).close(); // Should still be called even if the first one throws
+    }
+}

--- a/org.moreunit.core.test/src/org/moreunit/core/util/PreconditionsTest.java
+++ b/org.moreunit.core.test/src/org/moreunit/core/util/PreconditionsTest.java
@@ -3,7 +3,6 @@ package org.moreunit.core.util;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;

--- a/org.moreunit.core.test/src/org/moreunit/core/util/PreconditionsTest.java
+++ b/org.moreunit.core.test/src/org/moreunit/core/util/PreconditionsTest.java
@@ -1,0 +1,117 @@
+package org.moreunit.core.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class PreconditionsTest {
+
+    @Test
+    void testCheckNotNullSuccess() {
+        Object obj = new Object();
+        assertThat(Preconditions.checkNotNull(obj)).isSameAs(obj);
+    }
+
+    @Test
+    void testCheckNotNullFailure() {
+        assertThatThrownBy(() -> Preconditions.checkNotNull(null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testCheckNotNullWithMessageSuccess() {
+        Object obj = new Object();
+        assertThat(Preconditions.checkNotNull(obj, "message")).isSameAs(obj);
+    }
+
+    @Test
+    void testCheckNotNullWithMessageFailure() {
+        assertThatThrownBy(() -> Preconditions.checkNotNull(null, "Expected error message"))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("Expected error message");
+    }
+
+    @Test
+    void testCheckArgumentSuccess() {
+        Preconditions.checkArgument(true);
+        // should not throw exception
+    }
+
+    @Test
+    void testCheckArgumentFailure() {
+        assertThatThrownBy(() -> Preconditions.checkArgument(false))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testCheckArgumentWithMessageSuccess() {
+        Preconditions.checkArgument(true, "message");
+        // should not throw exception
+    }
+
+    @Test
+    void testCheckArgumentWithMessageFailure() {
+        assertThatThrownBy(() -> Preconditions.checkArgument(false, "Expected error message"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Expected error message");
+    }
+
+    @Test
+    void testCheckStateSuccess() {
+        Preconditions.checkState(true, "message");
+        // should not throw exception
+    }
+
+    @Test
+    void testCheckStateFailure() {
+        assertThatThrownBy(() -> Preconditions.checkState(false, "Expected error message"))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Expected error message");
+    }
+
+    @Test
+    void testCheckNotNullOrEmptySuccess() {
+        List<String> list = Arrays.asList("item");
+        assertThat(Preconditions.checkNotNullOrEmpty(list)).isSameAs(list);
+    }
+
+    @Test
+    void testCheckNotNullOrEmptyFailureNull() {
+        assertThatThrownBy(() -> Preconditions.checkNotNullOrEmpty((List<String>) null))
+            .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testCheckNotNullOrEmptyFailureEmpty() {
+        List<String> emptyList = Collections.emptyList();
+        assertThatThrownBy(() -> Preconditions.checkNotNullOrEmpty(emptyList))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testCheckNotNullOrEmptyWithMessageSuccess() {
+        List<String> list = Arrays.asList("item");
+        assertThat(Preconditions.checkNotNullOrEmpty(list, "message")).isSameAs(list);
+    }
+
+    @Test
+    void testCheckNotNullOrEmptyWithMessageFailureNull() {
+        assertThatThrownBy(() -> Preconditions.checkNotNullOrEmpty((List<String>) null, "Expected error message"))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessage("Expected error message");
+    }
+
+    @Test
+    void testCheckNotNullOrEmptyWithMessageFailureEmpty() {
+        List<String> emptyList = Collections.emptyList();
+        assertThatThrownBy(() -> Preconditions.checkNotNullOrEmpty(emptyList, "Expected error message"))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Expected error message");
+    }
+}

--- a/org.moreunit.core.test/src/org/moreunit/core/util/StringsTest.java
+++ b/org.moreunit.core.test/src/org/moreunit/core/util/StringsTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 
 import org.junit.jupiter.api.Test;
 

--- a/org.moreunit.core.test/src/org/moreunit/core/util/StringsTest.java
+++ b/org.moreunit.core.test/src/org/moreunit/core/util/StringsTest.java
@@ -1,0 +1,114 @@
+package org.moreunit.core.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class StringsTest {
+
+    @Test
+    void testIsBlank() {
+        assertThat(Strings.isBlank(null)).isTrue();
+        assertThat(Strings.isBlank("")).isTrue();
+        assertThat(Strings.isBlank("   ")).isTrue();
+        assertThat(Strings.isBlank(" a ")).isFalse();
+    }
+
+    @Test
+    void testEmptyIfNull() {
+        assertThat(Strings.emptyIfNull(null)).isEqualTo("");
+        assertThat(Strings.emptyIfNull("")).isEqualTo("");
+        assertThat(Strings.emptyIfNull("a")).isEqualTo("a");
+    }
+
+    @Test
+    void testNullIfBlank() {
+        assertThat(Strings.nullIfBlank(null)).isNull();
+        assertThat(Strings.nullIfBlank("")).isNull();
+        assertThat(Strings.nullIfBlank("   ")).isNull();
+        assertThat(Strings.nullIfBlank(" a ")).isEqualTo(" a ");
+    }
+
+    @Test
+    void testIsEmpty() {
+        assertThat(Strings.isEmpty(null)).isTrue();
+        assertThat(Strings.isEmpty("")).isTrue();
+        assertThat(Strings.isEmpty(" ")).isFalse();
+        assertThat(Strings.isEmpty("a")).isFalse();
+    }
+
+    @Test
+    void testCountOccurrences() {
+        assertThat(Strings.countOccurrences(null, "a")).isEqualTo(0);
+        assertThat(Strings.countOccurrences("a", null)).isEqualTo(0);
+        assertThat(Strings.countOccurrences("", "a")).isEqualTo(0);
+        assertThat(Strings.countOccurrences("a", "")).isEqualTo(0);
+
+        assertThat(Strings.countOccurrences("banana", "a")).isEqualTo(3);
+        assertThat(Strings.countOccurrences("banana", "na")).isEqualTo(2);
+        assertThat(Strings.countOccurrences("banana", "xyz")).isEqualTo(0);
+
+        assertThat(Strings.countOccurrences("aaaa", "aa")).isEqualTo(3);
+    }
+
+    @Test
+    void testSplit() {
+        assertThat(Strings.split("a,b,c", ",")).containsExactly("a", "b", "c");
+        assertThat(Strings.split(" a , b , c ", ",")).containsExactly("a", "b", "c");
+        assertThat(Strings.split("a,,c", ",")).containsExactly("a", "c");
+    }
+
+    @Test
+    void testSplitAsList() {
+        assertThat(Strings.splitAsList("a,b,c", ",")).containsExactly("a", "b", "c");
+        assertThat(Strings.splitAsList(" a , b , c ", ",")).containsExactly("a", "b", "c");
+        assertThat(Strings.splitAsList("a,,c", ",")).containsExactly("a", "c");
+    }
+
+    @Test
+    void testUcFirst() {
+        assertThat(Strings.ucFirst(null)).isNull();
+        assertThat(Strings.ucFirst("")).isEqualTo("");
+        assertThat(Strings.ucFirst("a")).isEqualTo("A");
+        assertThat(Strings.ucFirst("abc")).isEqualTo("Abc");
+        assertThat(Strings.ucFirst("Abc")).isEqualTo("Abc");
+    }
+
+    @Test
+    void testJoinVarargs() {
+        assertThat(Strings.join(",", "a", "b", "c")).isEqualTo("a,b,c");
+        assertThat(Strings.join(",", "a")).isEqualTo("a");
+        assertThat(Strings.join(",")).isEqualTo("");
+    }
+
+    @Test
+    void testJoinCollection() {
+        assertThat(Strings.join(",", Arrays.asList("a", "b", "c"))).isEqualTo("a,b,c");
+        assertThat(Strings.join(",", Arrays.asList("a"))).isEqualTo("a");
+        assertThat(Strings.join(",", Collections.emptyList())).isEqualTo("");
+    }
+
+    @Test
+    void testJoinStringBuilderArray() {
+        StringBuilder sb = new StringBuilder();
+        Strings.join(sb, ",", new String[] {"a", "b", "c"});
+        assertThat(sb.toString()).isEqualTo("a,b,c");
+    }
+
+    @Test
+    void testJoinStringBuilderCollection() {
+        StringBuilder sb = new StringBuilder("prefix-");
+        Strings.join(sb, ",", Arrays.asList("a", "b", "c"));
+        assertThat(sb.toString()).isEqualTo("prefix-a,b,c");
+    }
+
+    @Test
+    void testEmptyArray() {
+        assertThat(Strings.emptyArray()).isEmpty();
+        assertThat(Strings.emptyArray()).isSameAs(Strings.emptyArray());
+    }
+}


### PR DESCRIPTION
Added extensive test coverage for `org.moreunit.core.util` and `org.moreunit.core.matching` packages to ensure proper behaviors, particularly edge cases and null handling.

Tested classes:
- `ArrayUtilsTest`
- `IOUtilsTest`
- `PreconditionsTest`
- `StringsTest`
- `SourceFolderPathTest`

Rationale for mocking choices: Mockito is used to handle generic OSGi boundaries (like Eclipse's `Workspace` and `IFile`), maintaining isolation for the logic assertions without requiring a full Workbench boot.

---
*PR created automatically by Jules for task [13953465934131877305](https://jules.google.com/task/13953465934131877305) started by @RoiSoleil*