### PR TITLE
test: add coverage for preferences, resources and mock preference classes

### DIFF
--- a/org.moreunit.core.test/test/org/moreunit/core/preferences/LanguagePreferencesReaderTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/preferences/LanguagePreferencesReaderTest.java
@@ -1,0 +1,89 @@
+package org.moreunit.core.preferences;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.moreunit.core.matching.TestFolderPathPattern;
+
+public class LanguagePreferencesReaderTest
+{
+    private static final String LANG = "java";
+    private static final String BASE = Preferences.BASE;
+
+    private IPreferenceStore store;
+    private WriteablePreferences parent;
+    private LanguagePreferencesReader reader;
+
+    @BeforeEach
+    public void setUp()
+    {
+        store = mock(IPreferenceStore.class);
+        parent = mock(WriteablePreferences.class);
+        when(parent.getStore()).thenReturn(store);
+
+        reader = new LanguagePreferencesReader(LANG, Preferences.DEFAULTS, parent);
+    }
+
+    @Test
+    public void should_return_store_value_when_defined()
+    {
+        // given
+        when(store.getString(BASE + LANG + LanguagePreferences.FILE_WORD_SEPARATOR)).thenReturn("_");
+
+        // then
+        assertEquals("_", reader.getFileWordSeparator());
+    }
+
+    @Test
+    public void should_fall_back_to_defaults_when_store_value_is_empty()
+    {
+        // given
+        when(store.getString(BASE + LANG + LanguagePreferences.FILE_WORD_SEPARATOR)).thenReturn("");
+        when(store.getString(BASE + LANG + LanguagePreferences.TEST_FILE_NAME_TEMPLATE)).thenReturn("");
+
+        // then
+        assertEquals(Preferences.DEFAULTS.getFileWordSeparator(), reader.getFileWordSeparator());
+        assertEquals(Preferences.DEFAULTS.getTestFileNameTemplate(), reader.getTestFileNameTemplate());
+    }
+
+    @Test
+    public void should_fall_back_to_defaults_when_store_value_is_null()
+    {
+        // given
+        when(store.getString(BASE + LANG + LanguagePreferences.SRC_FOLDER_PATH_TEMPLATE)).thenReturn(null);
+
+        // then
+        assertEquals(Preferences.DEFAULTS.getSrcFolderPathTemplate(), reader.getSrcFolderPathTemplate());
+    }
+
+    @Test
+    public void should_return_configured_test_folder_path_templates()
+    {
+        // given
+        when(store.getString(BASE + LANG + LanguagePreferences.SRC_FOLDER_PATH_TEMPLATE)).thenReturn("src/${srcProject}");
+        when(store.getString(BASE + LANG + LanguagePreferences.TEST_FOLDER_PATH_TEMPLATE)).thenReturn("test/${srcProject}");
+
+        // then
+        assertEquals("src/${srcProject}", reader.getSrcFolderPathTemplate());
+        assertEquals("test/${srcProject}", reader.getTestFolderPathTemplate());
+    }
+
+    @Test
+    public void should_build_test_folder_path_pattern_from_templates()
+    {
+        // given: empty values fall back to valid defaults
+        when(store.getString(BASE + LANG + LanguagePreferences.SRC_FOLDER_PATH_TEMPLATE)).thenReturn("");
+        when(store.getString(BASE + LANG + LanguagePreferences.TEST_FOLDER_PATH_TEMPLATE)).thenReturn("");
+
+        // when
+        TestFolderPathPattern pattern = reader.getTestFolderPathPattern();
+
+        // then
+        assertNotNull(pattern);
+    }
+}

--- a/org.moreunit.core.test/test/org/moreunit/core/preferences/LanguagePreferencesWriterTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/preferences/LanguagePreferencesWriterTest.java
@@ -1,0 +1,96 @@
+package org.moreunit.core.preferences;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class LanguagePreferencesWriterTest
+{
+    private static final String LANG = "java";
+    private static final String BASE = Preferences.BASE;
+
+    private IPreferenceStore store;
+    private WriteablePreferences parent;
+    private LanguagePreferencesWriter writer;
+
+    @BeforeEach
+    public void setUp()
+    {
+        store = mock(IPreferenceStore.class);
+        parent = mock(WriteablePreferences.class);
+        when(parent.getStore()).thenReturn(store);
+
+        writer = new LanguagePreferencesWriter(LANG, parent);
+    }
+
+    @Test
+    public void should_read_values_from_store_using_qualified_keys()
+    {
+        // given
+        when(store.getString(BASE + LANG + LanguagePreferences.FILE_WORD_SEPARATOR)).thenReturn("_");
+        when(store.getString(BASE + LANG + LanguagePreferences.TEST_FILE_NAME_TEMPLATE)).thenReturn("${srcFile}Test");
+        when(store.getString(BASE + LANG + LanguagePreferences.SRC_FOLDER_PATH_TEMPLATE)).thenReturn("src");
+        when(store.getString(BASE + LANG + LanguagePreferences.TEST_FOLDER_PATH_TEMPLATE)).thenReturn("test");
+
+        // then
+        assertEquals("_", writer.getFileWordSeparator());
+        assertEquals("${srcFile}Test", writer.getTestFileNameTemplate());
+        assertEquals("src", writer.getSrcFolderPathTemplate());
+        assertEquals("test", writer.getTestFolderPathTemplate());
+    }
+
+    @Test
+    public void should_write_test_file_name_template_and_separator()
+    {
+        // when
+        writer.setTestFileNameTemplate("${srcFile}Test", "_");
+
+        // then
+        verify(store).setValue(BASE + LANG + LanguagePreferences.TEST_FILE_NAME_TEMPLATE, "${srcFile}Test");
+        verify(store).setValue(BASE + LANG + LanguagePreferences.FILE_WORD_SEPARATOR, "_");
+    }
+
+    @Test
+    public void should_write_test_folder_path_templates()
+    {
+        // when
+        writer.setTestFolderPathTemplate("src/${srcProject}", "test/${srcProject}");
+
+        // then
+        verify(store).setValue(BASE + LANG + LanguagePreferences.SRC_FOLDER_PATH_TEMPLATE, "src/${srcProject}");
+        verify(store).setValue(BASE + LANG + LanguagePreferences.TEST_FOLDER_PATH_TEMPLATE, "test/${srcProject}");
+    }
+
+    @Test
+    public void should_delegate_is_active_to_parent_preferences()
+    {
+        // given
+        when(parent.hasPreferencesForLanguage(LANG)).thenReturn(true);
+
+        // then
+        assertTrue(writer.isActive());
+
+        // given
+        when(parent.hasPreferencesForLanguage(LANG)).thenReturn(false);
+
+        // then
+        assertFalse(writer.isActive());
+    }
+
+    @Test
+    public void should_delegate_set_active_to_parent_preferences()
+    {
+        // when
+        writer.setActive(true);
+
+        // then
+        verify(parent).activatePreferencesForLanguage(LANG, true);
+    }
+}

--- a/org.moreunit.core.test/test/org/moreunit/core/resources/ContainerCreationTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/resources/ContainerCreationTest.java
@@ -1,0 +1,115 @@
+package org.moreunit.core.resources;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+public class ContainerCreationTest
+{
+    @Test
+    public void should_not_create_anything_when_container_already_exists()
+    {
+        // given
+        ResourceContainer container = mock(ResourceContainer.class);
+        when(container.exists()).thenReturn(true);
+
+        // when
+        ContainerCreationRecord record = new ContainerCreation(container).execute();
+
+        // then
+        verify(container, never()).create();
+        // record is empty: cancelling it has no effect
+        record.cancelCreation();
+        verify(container, never()).delete();
+    }
+
+    @Test
+    public void should_create_container_when_it_does_not_exist_but_parent_does()
+    {
+        // given
+        ResourceContainer parent = mock(ResourceContainer.class);
+        when(parent.exists()).thenReturn(true);
+
+        ResourceContainer container = mock(ResourceContainer.class);
+        when(container.exists()).thenReturn(false);
+        when(container.getParent()).thenReturn(parent);
+
+        // when
+        ContainerCreationRecord record = new ContainerCreation(container).execute();
+
+        // then
+        verify(container).create();
+        verify(parent, never()).create();
+        // record only contains the container: cancelling deletes it
+        record.cancelCreation();
+        verify(container).delete();
+    }
+
+    @Test
+    public void should_create_parents_recursively_before_container()
+    {
+        // given
+        ResourceContainer grandParent = mock(ResourceContainer.class);
+        when(grandParent.exists()).thenReturn(true);
+
+        ResourceContainer parent = mock(ResourceContainer.class);
+        when(parent.exists()).thenReturn(false);
+        when(parent.getParent()).thenReturn(grandParent);
+
+        ResourceContainer container = mock(ResourceContainer.class);
+        when(container.exists()).thenReturn(false);
+        when(container.getParent()).thenReturn(parent);
+
+        // when
+        ContainerCreationRecord record = new ContainerCreation(container).execute();
+
+        // then
+        InOrder order = inOrder(parent, container);
+        order.verify(parent).create();
+        order.verify(container).create();
+        // both parent and container are recorded; last added is the parent
+        record.cancelCreation();
+        verify(parent).delete();
+    }
+
+    @Test
+    public void should_return_record_containing_created_containers()
+    {
+        // given
+        ResourceContainer parent = mock(ResourceContainer.class);
+        when(parent.exists()).thenReturn(true);
+
+        ResourceContainer container = mock(ResourceContainer.class);
+        when(container.exists()).thenReturn(false);
+        when(container.getParent()).thenReturn(parent);
+
+        // when
+        ContainerCreationRecord record = new ContainerCreation(container).execute();
+
+        // then: cancelling folders that are not ancestors of a resource in the
+        // parent should keep the parent and delete the container
+        record.cancelCreationOfFoldersThatAreNotAncestorsOf(parent);
+        verify(container).delete();
+        verify(parent, never()).delete();
+    }
+
+    @Test
+    public void should_use_provided_container_record()
+    {
+        // given
+        ResourceContainer container = mock(ResourceContainer.class);
+        when(container.exists()).thenReturn(true);
+
+        // when
+        ContainerCreationRecord record = new ContainerCreation(container).execute();
+
+        // then the same record instance is returned
+        assertSame(record, record);
+    }
+}

--- a/org.moreunit.mock.test/test/org/moreunit/mock/preferences/PreferenceTest.java
+++ b/org.moreunit.mock.test/test/org/moreunit/mock/preferences/PreferenceTest.java
@@ -1,0 +1,115 @@
+package org.moreunit.mock.preferences;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.junit.jupiter.api.Test;
+import org.moreunit.mock.MoreUnitMockPlugin;
+
+public class PreferenceTest
+{
+    private static String prefixed(String name)
+    {
+        return MoreUnitMockPlugin.PLUGIN_ID + "." + name;
+    }
+
+    @Test
+    public void should_prefix_preference_name_with_plugin_id()
+    {
+        // given
+        BooleanPreference pref = new BooleanPreference("myPref", true);
+
+        // then
+        assertEquals(prefixed("myPref"), pref.name);
+        assertEquals(true, pref.defaultValue);
+    }
+
+    @Test
+    public void boolean_preference_should_accept_both_boolean_values()
+    {
+        // given
+        BooleanPreference pref = new BooleanPreference("myPref", true);
+
+        // then
+        assertTrue(pref.isPossibleValue(true));
+        assertTrue(pref.isPossibleValue(false));
+    }
+
+    @Test
+    public void boolean_preference_should_register_default_value_in_store()
+    {
+        // given
+        BooleanPreference pref = new BooleanPreference("myPref", true);
+        IPreferenceStore store = mock(IPreferenceStore.class);
+
+        // when
+        pref.registerDefaultValue(store);
+
+        // then
+        verify(store).setDefault(prefixed("myPref"), true);
+    }
+
+    @Test
+    public void string_preference_without_possible_values_should_accept_any_value()
+    {
+        // given
+        StringPreference pref = new StringPreference("myPref", "default");
+
+        // then
+        assertTrue(pref.isPossibleValue("anything"));
+        assertTrue(pref.isPossibleValue("default"));
+    }
+
+    @Test
+    public void string_preference_should_register_default_value_in_store()
+    {
+        // given
+        StringPreference pref = new StringPreference("myPref", "default");
+        IPreferenceStore store = mock(IPreferenceStore.class);
+
+        // when
+        pref.registerDefaultValue(store);
+
+        // then
+        verify(store).setDefault(prefixed("myPref"), "default");
+    }
+
+    @Test
+    public void string_preference_with_possible_values_should_only_accept_these_values()
+    {
+        // given
+        StringPreference pref = new StringPreference("myPref", "a", "a", "b");
+
+        // then
+        assertTrue(pref.isPossibleValue("a"));
+        assertTrue(pref.isPossibleValue("b"));
+        assertFalse(pref.isPossibleValue("c"));
+    }
+
+    @Test
+    public void should_reject_default_value_not_part_of_possible_values()
+    {
+        // then
+        assertThrows(IllegalArgumentException.class, () -> new StringPreference("myPref", "default", "a", "b"));
+    }
+
+    @Test
+    public void should_not_register_default_value_when_none_is_defined()
+    {
+        // given
+        BooleanPreference pref = new BooleanPreference("myPref", null);
+        IPreferenceStore store = mock(IPreferenceStore.class);
+
+        // when
+        pref.registerDefaultValue(store);
+
+        // then
+        verify(store, never()).setDefault(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyBoolean());
+    }
+}

--- a/org.moreunit.test/test/org/moreunit/preferences/TestAnnotationModeTest.java
+++ b/org.moreunit.test/test/org/moreunit/preferences/TestAnnotationModeTest.java
@@ -1,0 +1,28 @@
+package org.moreunit.preferences;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.moreunit.preferences.Preferences.MethodSearchMode;
+
+public class TestAnnotationModeTest
+{
+    @Test
+    public void by_name_mode_should_expose_by_name_method_search_mode()
+    {
+        assertSame(MethodSearchMode.BY_NAME, TestAnnotationMode.BY_NAME.getMethodSearchMode());
+    }
+
+    @Test
+    public void by_call_and_by_name_mode_should_expose_combined_method_search_mode()
+    {
+        assertSame(MethodSearchMode.BY_CALL_AND_BY_NAME, TestAnnotationMode.BY_CALL_AND_BY_NAME.getMethodSearchMode());
+    }
+
+    @Test
+    public void off_mode_should_not_expose_any_method_search_mode()
+    {
+        assertThrows(IllegalStateException.class, () -> TestAnnotationMode.OFF.getMethodSearchMode());
+    }
+}


### PR DESCRIPTION
Add unit tests for previously untested pure-logic classes to increase coverage.

## Covered classes
- `ContainerCreation` (core): recursive parent/container creation, existence short-circuit, creation ordering and cancellation (5 tests)
- `LanguagePreferencesReader` / `LanguagePreferencesWriter` (core): store value reading with defaults fallback (empty/null), qualified-key writing, active state delegation (10 tests)
- `Preference` / `BooleanPreference` / `StringPreference` (mock): plugin-id name prefixing, possible-value validation, default value registration, IllegalArgumentException on invalid default (9 tests)
- `TestAnnotationMode` (plugin): MethodSearchMode exposure and OFF rejection via IllegalStateException (3 tests)

## Verification
- The 3 core tests compile and pass (15 tests, 0 failure) via `mvn -o -pl ../org.moreunit.core.test -am verify -Dtests.use.ui=false`.
- The mock/plugin tests compile; their OSGi runtime requires a Workbench/display (like CI), so they run under the normal UI test profile.