### PR TITLE
test: add coverage for matching, resources, elements and expressions

### DIFF
--- a/org.moreunit.core.test/test/org/moreunit/core/expressions/FileTesterTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/expressions/FileTesterTest.java
@@ -1,0 +1,54 @@
+package org.moreunit.core.expressions;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.core.resources.IFile;
+import org.junit.jupiter.api.Test;
+import org.moreunit.core.resources.SrcFile;
+import org.moreunit.core.resources.Workspace;
+
+public class FileTesterTest
+{
+    private final Workspace workspace = mock(Workspace.class);
+    private final FileTester tester = new FileTester(workspace);
+
+    @Test
+    public void should_return_false_when_receiver_is_not_a_file()
+    {
+        assertFalse(tester.test("not a file", "hasDefaultSupport", new Object[0], null));
+    }
+
+    @Test
+    public void should_return_false_when_method_is_not_supported()
+    {
+        IFile file = mock(IFile.class);
+
+        assertFalse(tester.test(file, "unknownMethod", new Object[0], null));
+    }
+
+    @Test
+    public void has_default_support_should_return_true_when_expected_value_is_false()
+    {
+        IFile file = mock(IFile.class);
+        when(workspace.toSrcFile(file)).thenReturn(mock(SrcFile.class));
+
+        assertTrue(tester.test(file, "hasDefaultSupport", new Object[0], "false"));
+    }
+
+    @Test
+    public void has_default_support_should_delegate_to_file_when_expected_value_is_not_false()
+    {
+        IFile file = mock(IFile.class);
+        SrcFile srcFile = mock(SrcFile.class);
+        when(workspace.toSrcFile(file)).thenReturn(srcFile);
+
+        when(srcFile.hasDefaultSupport()).thenReturn(true);
+        assertTrue(tester.test(file, "hasDefaultSupport", new Object[0], null));
+
+        when(srcFile.hasDefaultSupport()).thenReturn(false);
+        assertFalse(tester.test(file, "hasDefaultSupport", new Object[0], null));
+    }
+}

--- a/org.moreunit.core.test/test/org/moreunit/core/resources/CreatedFolderPathTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/resources/CreatedFolderPathTest.java
@@ -1,0 +1,91 @@
+package org.moreunit.core.resources;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.IPath;
+import org.junit.jupiter.api.Test;
+
+public class CreatedFolderPathTest
+{
+    @Test
+    public void delete_should_delete_the_resource_of_a_single_folder() throws Exception
+    {
+        IResource resource = mock(IResource.class);
+
+        new CreatedFolderPath(resource).delete();
+
+        verify(resource).delete(true, null);
+    }
+
+    @Test
+    public void delete_should_delete_the_first_created_folder_not_the_child() throws Exception
+    {
+        IResource parentResource = mock(IResource.class);
+        IResource childResource = mock(IResource.class);
+
+        CreatedFolderPath parent = new CreatedFolderPath(parentResource);
+        CreatedFolderPath child = new CreatedFolderPath(parent, childResource);
+
+        child.delete();
+
+        verify(parentResource).delete(true, null);
+        verify(childResource, never()).delete(anyBoolean(), any());
+    }
+
+    @Test
+    public void delete_folders_that_are_not_parent_should_delete_non_ancestor_child() throws Exception
+    {
+        IResource parentResource = mock(IResource.class);
+        IResource childResource = mock(IResource.class);
+        IResource otherResource = mock(IResource.class);
+
+        IPath parentPath = mock(IPath.class);
+        IPath childPath = mock(IPath.class);
+        IPath otherPath = mock(IPath.class);
+
+        when(parentResource.getFullPath()).thenReturn(parentPath);
+        when(childResource.getFullPath()).thenReturn(childPath);
+        when(otherResource.getFullPath()).thenReturn(otherPath);
+
+        when(childPath.isPrefixOf(otherPath)).thenReturn(false);
+        when(parentPath.isPrefixOf(otherPath)).thenReturn(true);
+
+        CreatedFolderPath parent = new CreatedFolderPath(parentResource);
+        CreatedFolderPath child = new CreatedFolderPath(parent, childResource);
+
+        child.deleteFoldersThatAreNotParentOf(otherResource);
+
+        verify(childResource).delete(true, null);
+        verify(parentResource, never()).delete(anyBoolean(), any());
+    }
+
+    @Test
+    public void delete_folders_that_are_not_parent_should_do_nothing_when_resource_is_parent() throws Exception
+    {
+        IResource resource = mock(IResource.class);
+        IResource otherResource = mock(IResource.class);
+        IPath path = mock(IPath.class);
+        IPath otherPath = mock(IPath.class);
+
+        when(resource.getFullPath()).thenReturn(path);
+        when(otherResource.getFullPath()).thenReturn(otherPath);
+        when(path.isPrefixOf(otherPath)).thenReturn(true);
+
+        new CreatedFolderPath(resource).deleteFoldersThatAreNotParentOf(otherResource);
+
+        verify(resource, never()).delete(anyBoolean(), any());
+    }
+
+    @Test
+    public void to_string_should_be_empty_when_no_resource()
+    {
+        assertEquals("", new CreatedFolderPath((IResource) null).toString());
+    }
+}

--- a/org.moreunit.test/test/org/moreunit/annotation/MoreUnitAnnotationTest.java
+++ b/org.moreunit.test/test/org/moreunit/annotation/MoreUnitAnnotationTest.java
@@ -1,0 +1,26 @@
+package org.moreunit.annotation;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+import org.eclipse.jdt.core.ISourceRange;
+import org.junit.jupiter.api.Test;
+
+public class MoreUnitAnnotationTest
+{
+    @Test
+    public void create_annotation_for_tested_method_should_return_annotation()
+    {
+        ISourceRange range = mock(ISourceRange.class);
+
+        assertNotNull(MoreUnitAnnotation.createAnnotationForTestedMethod(range));
+    }
+
+    @Test
+    public void create_annotation_for_ignored_test_method_should_return_annotation()
+    {
+        ISourceRange range = mock(ISourceRange.class);
+
+        assertNotNull(MoreUnitAnnotation.createAnnotationForIgnoredTesMethod(range));
+    }
+}

--- a/org.moreunit.test/test/org/moreunit/elements/CorrespondingMemberRequestTest.java
+++ b/org.moreunit.test/test/org/moreunit/elements/CorrespondingMemberRequestTest.java
@@ -1,0 +1,76 @@
+package org.moreunit.elements;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import org.eclipse.jdt.core.IMethod;
+import org.junit.jupiter.api.Test;
+import org.moreunit.elements.CorrespondingMemberRequest.MemberType;
+import org.moreunit.preferences.Preferences.MethodSearchMode;
+
+public class CorrespondingMemberRequestTest
+{
+    @Test
+    public void default_request_should_use_default_values()
+    {
+        CorrespondingMemberRequest request = CorrespondingMemberRequest.newCorrespondingMemberRequest().build();
+
+        assertFalse(request.shouldCreateClassIfNoResult());
+        assertEquals(MethodSearchMode.DEFAULT, request.getMethodSearchMode());
+        assertNull(request.getPromptText());
+        assertNull(request.getCurrentMethod());
+        assertTrue(request.shouldReturn(MemberType.TYPE_OR_METHOD));
+        assertFalse(request.shouldReturn(MemberType.TYPE));
+    }
+
+    @Test
+    public void should_configure_method_search_mode_and_current_method()
+    {
+        IMethod method = mock(org.eclipse.jdt.core.IMethod.class);
+
+        CorrespondingMemberRequest request = CorrespondingMemberRequest.newCorrespondingMemberRequest() //
+                .withCurrentMethod(method) //
+                .methodSearchMode(MethodSearchMode.BY_NAME) //
+                .build();
+
+        assertSame(method, request.getCurrentMethod());
+        assertEquals(MethodSearchMode.BY_NAME, request.getMethodSearchMode());
+    }
+
+    @Test
+    public void should_configure_expected_result_type()
+    {
+        CorrespondingMemberRequest request = CorrespondingMemberRequest.newCorrespondingMemberRequest() //
+                .withExpectedResultType(MemberType.TYPE) //
+                .build();
+
+        assertTrue(request.shouldReturn(MemberType.TYPE));
+        assertFalse(request.shouldReturn(MemberType.TYPE_OR_METHOD));
+    }
+
+    @Test
+    public void create_class_if_no_result_should_enable_creation_and_set_prompt_text()
+    {
+        CorrespondingMemberRequest request = CorrespondingMemberRequest.newCorrespondingMemberRequest() //
+                .createClassIfNoResult("Choose a member") //
+                .build();
+
+        assertTrue(request.shouldCreateClassIfNoResult());
+        assertEquals("Choose a member", request.getPromptText());
+    }
+
+    @Test
+    public void prompt_text_should_be_set_without_enabling_class_creation()
+    {
+        CorrespondingMemberRequest request = CorrespondingMemberRequest.newCorrespondingMemberRequest() //
+                .promptText("hint") //
+                .build();
+
+        assertFalse(request.shouldCreateClassIfNoResult());
+        assertEquals("hint", request.getPromptText());
+    }
+}

--- a/org.moreunit.test/test/org/moreunit/elements/SourceFolderMappingTest.java
+++ b/org.moreunit.test/test/org/moreunit/elements/SourceFolderMappingTest.java
@@ -1,0 +1,66 @@
+package org.moreunit.elements;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.junit.jupiter.api.Test;
+
+public class SourceFolderMappingTest
+{
+    @Test
+    public void three_arg_constructor_should_init_project_source_and_test_folders()
+    {
+        IJavaProject project = mock(IJavaProject.class);
+        IPackageFragmentRoot sourceFolder = mock(IPackageFragmentRoot.class);
+        IPackageFragmentRoot testFolder = mock(IPackageFragmentRoot.class);
+
+        SourceFolderMapping mapping = new SourceFolderMapping(project, sourceFolder, testFolder);
+
+        assertSame(project, mapping.getJavaProject());
+        assertSame(testFolder, mapping.getTestFolder());
+        assertEquals(1, mapping.getSourceFolderList().size());
+        assertSame(sourceFolder, mapping.getSourceFolderList().get(0));
+    }
+
+    @Test
+    public void set_source_folder_list_should_replace_the_list()
+    {
+        IJavaProject project = mock(IJavaProject.class);
+        IPackageFragmentRoot sourceFolder = mock(IPackageFragmentRoot.class);
+        IPackageFragmentRoot testFolder = mock(IPackageFragmentRoot.class);
+        IPackageFragmentRoot otherSource = mock(IPackageFragmentRoot.class);
+
+        SourceFolderMapping mapping = new SourceFolderMapping(project, sourceFolder, testFolder);
+        mapping.setSourceFolderList(List.of(otherSource));
+
+        assertEquals(1, mapping.getSourceFolderList().size());
+        assertSame(otherSource, mapping.getSourceFolderList().get(0));
+    }
+
+    @Test
+    public void to_string_should_describe_source_to_test_mapping()
+    {
+        IJavaProject project = mock(IJavaProject.class);
+        IPackageFragmentRoot sourceFolder = mock(IPackageFragmentRoot.class);
+        IPackageFragmentRoot testFolder = mock(IPackageFragmentRoot.class);
+
+        when(project.getElementName()).thenReturn("Proj");
+        when(sourceFolder.getJavaProject()).thenReturn(project);
+        when(sourceFolder.getElementName()).thenReturn("src");
+        when(testFolder.getJavaProject()).thenReturn(project);
+        when(testFolder.getElementName()).thenReturn("test");
+
+        SourceFolderMapping mapping = new SourceFolderMapping(project, sourceFolder, testFolder);
+
+        String str = mapping.toString();
+        assertTrue(str.contains("SourceFolderMapping"));
+        assertTrue(str.contains("Proj:src => Proj:test"));
+    }
+}


### PR DESCRIPTION
Add unit tests for previously untested classes identified via the JaCoCo aggregate report.

## Covered classes
- `CreatedFolderPath` (core): recursive first-folder deletion, non-ancestor cleanup, empty toString when no resource (5 tests)
- `CorrespondingMemberRequest` (plugin): builder defaults and configuration (method search mode, expected type, prompt text, class creation) (5 tests)
- `SourceFolderMapping` (plugin): 3-arg constructor, source list replacement and toString (3 tests)
- `FileTester` (core): receiver/method guards and hasDefaultSupport delegation (4 tests)
- `MoreUnitAnnotation` (plugin): tested/ignored annotation factories (2 tests)

## Verification
All tests compile and pass: core tests via `-Dtests.use.ui=false`, plugin tests with the UI harness (`DISPLAY=:0`). JaCoCo confirms these classes were at 0% instruction coverage before.