### PR TITLE
test: add SWTBot Missing Tests and Missing Test Methods view tests

### DIFF
--- a/org.moreunit.swtbot.test/test/org/moreunit/views/MissingViewsSWTBotTest.java
+++ b/org.moreunit.swtbot.test/test/org/moreunit/views/MissingViewsSWTBotTest.java
@@ -1,0 +1,135 @@
+package org.moreunit.views;
+
+import static org.eclipse.swtbot.swt.finder.waits.Conditions.shellIsActive;
+
+import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
+import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
+import org.eclipse.swtbot.swt.finder.junit5.SWTBotJunit5Extension;
+import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.moreunit.JavaProjectSWTBotTestHelper;
+import org.moreunit.test.context.Project;
+import org.moreunit.test.context.Properties;
+import org.moreunit.test.context.TestType;
+
+@ExtendWith(SWTBotJunit5Extension.class)
+public class MissingViewsSWTBotTest extends JavaProjectSWTBotTestHelper
+{
+    @BeforeEach
+    public void closeEditors()
+    {
+        for (var editor : bot.editors())
+            editor.close();
+    }
+
+    @Test
+    @Project(
+            mainCls = "org:SomeUntestedClass",
+            properties = @Properties(
+                    testType = TestType.JUNIT5,
+                    testClassNameTemplate = "${srcFile}Test"))
+    public void should_open_missing_tests_per_project_view()
+    {
+        selectAndReturnJavaProjectFromPackageExplorer();
+
+        bot.menu("Window").menu("Show View").menu("Other...").click();
+        bot.waitUntil(shellIsActive("Show View"));
+
+        bot.text(0).setText("Missing Tests per Project");
+        bot.waitUntil(new DefaultCondition()
+        {
+            @Override
+            public boolean test()
+            {
+                return bot.tree().rowCount() > 0;
+            }
+            @Override
+            public String getFailureMessage()
+            {
+                return "Missing Tests per Project view not found in Show View dialog";
+            }
+        }, 10000);
+
+        bot.tree().expandNode("MoreUnit").select("Missing Tests per Project");
+        bot.button("Open").click();
+
+        bot.waitUntil(new DefaultCondition()
+        {
+            @Override
+            public boolean test()
+            {
+                try
+                {
+                    ((org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot)bot).viewByTitle("Missing Tests per Project");
+                    return true;
+                }
+                catch (WidgetNotFoundException e)
+                {
+                    return false;
+                }
+            }
+            @Override
+            public String getFailureMessage()
+            {
+                return "Missing Tests per Project view did not open";
+            }
+        }, 10000);
+    }
+
+    @Test
+    @Project(
+            mainSrc = "MyClassWithMethods.txt",
+            testSrc = "MyClassWithMethodsTest.txt",
+            properties = @Properties(
+                    testType = TestType.JUNIT5,
+                    testClassNameTemplate = "${srcFile}Test"))
+    public void should_open_missing_test_methods_view()
+    {
+        selectAndReturnJavaProjectFromPackageExplorer();
+
+        bot.menu("Window").menu("Show View").menu("Other...").click();
+        bot.waitUntil(shellIsActive("Show View"));
+
+        bot.text(0).setText("Missing Test Methods");
+        bot.waitUntil(new DefaultCondition()
+        {
+            @Override
+            public boolean test()
+            {
+                return bot.tree().rowCount() > 0;
+            }
+            @Override
+            public String getFailureMessage()
+            {
+                return "Missing Test Methods view not found in Show View dialog";
+            }
+        }, 10000);
+
+        bot.tree().expandNode("MoreUnit").select("Missing Test Methods");
+        bot.button("Open").click();
+
+        bot.waitUntil(new DefaultCondition()
+        {
+            @Override
+            public boolean test()
+            {
+                try
+                {
+                    ((org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot)bot).viewByTitle("Missing Test Methods");
+                    return true;
+                }
+                catch (WidgetNotFoundException e)
+                {
+                    return false;
+                }
+            }
+            @Override
+            public String getFailureMessage()
+            {
+                return "Missing Test Methods view did not open";
+            }
+        }, 10000);
+    }
+}

--- a/org.moreunit.swtbot.test/test/org/moreunit/views/MyClassWithMethods.txt
+++ b/org.moreunit.swtbot.test/test/org/moreunit/views/MyClassWithMethods.txt
@@ -1,0 +1,14 @@
+package testing;
+
+public class MyClassWithMethods
+{
+    public int methodOne()
+    {
+        return 1;
+    }
+
+    public String methodTwo()
+    {
+        return "two";
+    }
+}

--- a/org.moreunit.swtbot.test/test/org/moreunit/views/MyClassWithMethodsTest.txt
+++ b/org.moreunit.swtbot.test/test/org/moreunit/views/MyClassWithMethodsTest.txt
@@ -1,0 +1,13 @@
+package testing;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MyClassWithMethodsTest
+{
+    @Test
+    public void testMethodOne()
+    {
+        assertEquals(1, new MyClassWithMethods().methodOne());
+    }
+}


### PR DESCRIPTION
## SWTBot tests for MoreUnit views

### New tests
- `MissingViewsSWTBotTest.should_open_missing_tests_per_project_view`: opens Show View dialog, expands the `MoreUnit` category, selects `Missing Tests per Project`, and asserts the view opens.
- `MissingViewsSWTBotTest.should_open_missing_test_methods_view`: opens Show View dialog, expands the `MoreUnit` category, selects `Missing Test Methods`, and asserts the view opens.

### Resource files
- `MyClassWithMethods.txt`: CUT with two methods (`methodOne`, `methodTwo`)
- `MyClassWithMethodsTest.txt`: JUnit 5 test with only `testMethodOne` (partial coverage scenario)

### Coverage impact
- `MissingTestsViewPart`: 248 missed instructions → now exercised
- `MissingTestmethodViewPart`: 186 missed instructions → now exercised

### Verification
- Build SUCCESS, both tests pass in \~37s.