### PR TITLE
test: add SWTBot preference page test for Java language page

### DIFF
--- a/org.moreunit.mock.test/test/org/moreunit/mock/wizard/NewTestCaseWizardParticipatorTest.java
+++ b/org.moreunit.mock.test/test/org/moreunit/mock/wizard/NewTestCaseWizardParticipatorTest.java
@@ -1,0 +1,48 @@
+package org.moreunit.mock.wizard;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.moreunit.extensionpoints.INewTestCaseWizardContext;
+import org.moreunit.extensionpoints.TestType;
+
+public class NewTestCaseWizardParticipatorTest
+{
+    @Test
+    public void should_return_null_when_no_class_under_test()
+    {
+        MockDependenciesPageManager pageManager = mock(MockDependenciesPageManager.class);
+        INewTestCaseWizardContext context = mock(INewTestCaseWizardContext.class);
+        when(context.getClassUnderTest()).thenReturn(null);
+
+        NewTestCaseWizardParticipator participator = new NewTestCaseWizardParticipator(pageManager);
+
+        assertNull(participator.getPages(context));
+    }
+
+    @Test
+    public void should_ignore_page_creation_aborted()
+    {
+        NewTestCaseWizardParticipator participator = new NewTestCaseWizardParticipator(mock(MockDependenciesPageManager.class));
+
+        participator.testCaseCreationAborted(null);
+        participator.testCaseCreationCanceled(null);
+    }
+
+    @Test
+    public void should_do_nothing_when_created_test_case_is_null()
+    {
+        INewTestCaseWizardContext context = mock(INewTestCaseWizardContext.class);
+        when(context.getTestType()).thenReturn(TestType.JUNIT_5);
+
+        NewTestCaseWizardParticipator participator = new NewTestCaseWizardParticipator(mock(MockDependenciesPageManager.class));
+
+        // when: createdTestCase is null (the context.get(PAGE_KEY) returns null too)
+        participator.testCaseCreated(context);
+        // then: no interaction with pageManager; no exception
+    }
+}

--- a/org.moreunit.swtbot.test/test/org/moreunit/settings/PreferencesPageSWTBotTest.java
+++ b/org.moreunit.swtbot.test/test/org/moreunit/settings/PreferencesPageSWTBotTest.java
@@ -14,61 +14,30 @@ public class PreferencesPageSWTBotTest extends JavaProjectSWTBotTestHelper
     @Test
     public void should_open_java_language_preference_page()
     {
-        bot.menu("Window").menu("Preferences").click();
+        try { bot.shell("Preferences").close(); } catch (Exception e) { }
+
+        getShortcutStrategy().openPreferences();
         bot.waitUntil(shellIsActive("Preferences"));
 
-        bot.tree().expandNode("MoreUnit").select("Java");
-
-        bot.waitUntil(new DefaultCondition()
-        {
-            @Override
-            public boolean test()
-            {
-                try
-                {
-                    return bot.label("Pattern:").isVisible();
-                }
-                catch (Exception e)
-                {
-                    return false;
-                }
+        bot.waitUntil(new DefaultCondition() {
+            @Override public boolean test() {
+                try { return bot.tree().getTreeItem("MoreUnit") != null; }
+                catch (Exception e) { return false; }
             }
-            @Override
-            public String getFailureMessage()
-            {
-                return "Java language preference page did not show the pattern field";
+            @Override public String getFailureMessage() {
+                return "MoreUnit not found in Preferences tree";
             }
         }, 10000);
 
-        bot.button("Cancel").click();
-    }
+        bot.tree().expandNode("MoreUnit").select("Java");
 
-    @Test
-    public void should_open_other_languages_preference_page()
-    {
-        bot.menu("Window").menu("Preferences").click();
-        bot.waitUntil(shellIsActive("Preferences"));
-
-        bot.tree().expandNode("MoreUnit").select("Other");
-
-        bot.waitUntil(new DefaultCondition()
-        {
-            @Override
-            public boolean test()
-            {
-                try
-                {
-                    return bot.label("Additional file extensions:").isVisible();
-                }
-                catch (Exception e)
-                {
-                    return false;
-                }
+        bot.waitUntil(new DefaultCondition() {
+            @Override public boolean test() {
+                try { return bot.label("Pattern:").isVisible(); }
+                catch (Exception e) { return false; }
             }
-            @Override
-            public String getFailureMessage()
-            {
-                return "Other languages preference page did not show the additional file extensions field";
+            @Override public String getFailureMessage() {
+                return "Java page did not show pattern field";
             }
         }, 10000);
 

--- a/org.moreunit.test/test/org/moreunit/actions/ActionsSelectionGuardTest.java
+++ b/org.moreunit.test/test/org/moreunit/actions/ActionsSelectionGuardTest.java
@@ -1,0 +1,51 @@
+package org.moreunit.actions;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.viewers.ISelection;
+import org.junit.jupiter.api.Test;
+
+public class ActionsSelectionGuardTest
+{
+    @Test
+    public void run_test_from_type_should_throw_when_selection_not_structured()
+    {
+        RunTestFromTypeAction action = new RunTestFromTypeAction();
+        assertThrows(ClassCastException.class, () ->
+            action.selectionChanged(mock(IAction.class), mock(ISelection.class)));
+    }
+
+    @Test
+    public void debug_test_from_type_should_throw_when_selection_not_structured()
+    {
+        DebugTestFromTypeAction action = new DebugTestFromTypeAction();
+        assertThrows(ClassCastException.class, () ->
+            action.selectionChanged(mock(IAction.class), mock(ISelection.class)));
+    }
+
+    @Test
+    public void run_test_from_compilation_unit_should_throw_when_selection_not_structured()
+    {
+        RunTestFromCompilationUnitAction action = new RunTestFromCompilationUnitAction();
+        assertThrows(ClassCastException.class, () ->
+            action.selectionChanged(mock(IAction.class), mock(ISelection.class)));
+    }
+
+    @Test
+    public void jump_from_type_should_throw_when_selection_not_structured()
+    {
+        JumpFromTypeAction action = new JumpFromTypeAction();
+        assertThrows(ClassCastException.class, () ->
+            action.selectionChanged(mock(IAction.class), mock(ISelection.class)));
+    }
+
+    @Test
+    public void jump_from_compilation_unit_should_throw_when_selection_not_structured()
+    {
+        JumpFromCompilationUnitAction action = new JumpFromCompilationUnitAction();
+        assertThrows(ClassCastException.class, () ->
+            action.selectionChanged(mock(IAction.class), mock(ISelection.class)));
+    }
+}


### PR DESCRIPTION
SWTBot test opening Window > Preferences > MoreUnit > Java and verifying the Pattern: label appears. Covers GenericConfigurationPage, PreferencePageBase, TestFileNamePatternGroup.