### PR TITLE
test: add EclipseFolder, MethodContentProvider and RenameDialogRunnable tests

### DIFF
--- a/org.moreunit.core.test/test/org/moreunit/core/resources/EclipseFolderTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/resources/EclipseFolderTest.java
@@ -1,0 +1,46 @@
+package org.moreunit.core.resources;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.IPath;
+import org.junit.jupiter.api.Test;
+
+public class EclipseFolderTest
+{
+    @Test
+    public void should_create_folder_from_ifolder()
+    {
+        IFolder ifolder = mock(IFolder.class);
+        IPath path = mock(IPath.class);
+        when(path.removeTrailingSeparator()).thenReturn(path);
+        when(ifolder.getFullPath()).thenReturn(path);
+
+        IProject project = mock(IProject.class);
+        when(ifolder.getProject()).thenReturn(project);
+
+        EclipseFolder folder = new EclipseFolder(ifolder);
+
+        assertNotNull(folder.getPath());
+    }
+
+    @Test
+    public void get_project_should_return_eclipse_project()
+    {
+        IFolder ifolder = mock(IFolder.class);
+        IPath path = mock(IPath.class);
+        when(path.removeTrailingSeparator()).thenReturn(path);
+        when(ifolder.getFullPath()).thenReturn(path);
+
+        IProject project = mock(IProject.class);
+        when(project.getFullPath()).thenReturn(path);
+        when(ifolder.getProject()).thenReturn(project);
+
+        EclipseFolder folder = new EclipseFolder(ifolder);
+
+        assertNotNull(folder.getProject());
+    }
+}

--- a/org.moreunit.test/test/org/moreunit/elements/MethodContentProviderTest.java
+++ b/org.moreunit.test/test/org/moreunit/elements/MethodContentProviderTest.java
@@ -1,0 +1,41 @@
+package org.moreunit.elements;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+
+import org.eclipse.jdt.core.IMethod;
+import org.junit.jupiter.api.Test;
+
+public class MethodContentProviderTest
+{
+    @Test
+    public void should_return_methods_as_elements()
+    {
+        IMethod method = mock(IMethod.class);
+        MethodContentProvider provider = new MethodContentProvider(List.of(method));
+
+        Object[] elements = provider.getElements(null);
+
+        assertEquals(1, elements.length);
+        assertNotNull(elements[0]);
+    }
+
+    @Test
+    public void should_return_empty_array_for_empty_list()
+    {
+        MethodContentProvider provider = new MethodContentProvider(List.of());
+
+        assertEquals(0, provider.getElements(null).length);
+    }
+
+    @Test
+    public void dispose_and_input_changed_should_not_throw()
+    {
+        MethodContentProvider provider = new MethodContentProvider(List.of());
+        provider.dispose();
+        provider.inputChanged(null, null, null);
+    }
+}

--- a/org.moreunit.test/test/org/moreunit/refactoring/RenameDialogRunnableTest.java
+++ b/org.moreunit.test/test/org/moreunit/refactoring/RenameDialogRunnableTest.java
@@ -1,0 +1,31 @@
+package org.moreunit.refactoring;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IMethod;
+import org.junit.jupiter.api.Test;
+import org.moreunit.elements.ClassTypeFacade;
+
+public class RenameDialogRunnableTest
+{
+    @Test
+    public void constructor_should_store_parameters_and_create_diviner()
+    {
+        ClassTypeFacade javaFile = mock(ClassTypeFacade.class);
+        ICompilationUnit cu = mock(ICompilationUnit.class);
+        when(javaFile.getCompilationUnit()).thenReturn(cu);
+
+        IMethod method = mock(IMethod.class);
+
+        RenameDialogRunnable runnable = new RenameDialogRunnable(javaFile, method, "newName");
+
+        assertEquals(method, runnable.renamedMethod);
+        assertEquals("newName", runnable.newMethodName);
+        assertNotNull(runnable.testMethodDivinerFactory);
+        assertNotNull(runnable.testMethodDiviner);
+    }
+}


### PR DESCRIPTION
Unit tests for:\n- EclipseFolder: constructor and getProject\n- MethodContentProvider: elements, empty list, dispose/inputChanged\n- RenameDialogRunnable: constructor stores parameters and creates diviner