### PR TITLE
test: add XmlTemplateDefinitionReader, FileMatcher, SeparatorElement and TestTypeConstants tests

### DIFF
--- a/org.moreunit.core.test/test/org/moreunit/core/matching/FileMatcherTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/matching/FileMatcherTest.java
@@ -1,0 +1,22 @@
+package org.moreunit.core.matching;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+import org.moreunit.core.resources.SrcFile;
+
+public class FileMatcherTest
+{
+    @Test
+    public void should_create_from_src_file_search_engine_and_selector()
+    {
+        SrcFile srcFile = mock(SrcFile.class);
+        SearchEngine searchEngine = mock(SearchEngine.class);
+        FileMatchSelector matchSelector = mock(FileMatchSelector.class);
+
+        FileMatcher matcher = new FileMatcher(srcFile, searchEngine, matchSelector);
+
+        assertNotNull(matcher);
+    }
+}

--- a/org.moreunit.core.test/test/org/moreunit/core/resources/EclipseFolderTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/resources/EclipseFolderTest.java
@@ -1,0 +1,46 @@
+package org.moreunit.core.resources;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.IPath;
+import org.junit.jupiter.api.Test;
+
+public class EclipseFolderTest
+{
+    @Test
+    public void should_create_folder_from_ifolder()
+    {
+        IFolder ifolder = mock(IFolder.class);
+        IPath path = mock(IPath.class);
+        when(path.removeTrailingSeparator()).thenReturn(path);
+        when(ifolder.getFullPath()).thenReturn(path);
+
+        IProject project = mock(IProject.class);
+        when(ifolder.getProject()).thenReturn(project);
+
+        EclipseFolder folder = new EclipseFolder(ifolder);
+
+        assertNotNull(folder.getPath());
+    }
+
+    @Test
+    public void get_project_should_return_eclipse_project()
+    {
+        IFolder ifolder = mock(IFolder.class);
+        IPath path = mock(IPath.class);
+        when(path.removeTrailingSeparator()).thenReturn(path);
+        when(ifolder.getFullPath()).thenReturn(path);
+
+        IProject project = mock(IProject.class);
+        when(project.getFullPath()).thenReturn(path);
+        when(ifolder.getProject()).thenReturn(project);
+
+        EclipseFolder folder = new EclipseFolder(ifolder);
+
+        assertNotNull(folder.getProject());
+    }
+}

--- a/org.moreunit.mock.test/test/org/moreunit/mock/templates/XmlTemplateDefinitionReaderTest.java
+++ b/org.moreunit.mock.test/test/org/moreunit/mock/templates/XmlTemplateDefinitionReaderTest.java
@@ -1,0 +1,48 @@
+package org.moreunit.mock.templates;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+
+public class XmlTemplateDefinitionReaderTest
+{
+    @Test
+    public void should_read_valid_xml() throws Exception
+    {
+        URL xsd = getClass().getResource("/templates/mocking-templates.xsd");
+        assertNotNull(xsd, "XSD resource not found");
+
+        XmlTemplateDefinitionReader reader = new XmlTemplateDefinitionReader(xsd);
+
+        String validXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+            + "<mocking-templates version=\"1.0\" xmlns=\"http://moreunit.org/mock/mocking-templates\">"
+            + "<mocking-template id=\"test.id\" category=\"test.cat\" name=\"Test\">"
+            + "<code-template id=\"body\" part=\"test-class-fields\">"
+            + "<pattern><![CDATA[test]]></pattern>"
+            + "</code-template>"
+            + "</mocking-template>"
+            + "</mocking-templates>";
+        InputStream is = new ByteArrayInputStream(validXml.getBytes());
+
+        assertNotNull(reader.read(is));
+    }
+
+    @Test
+    public void should_throw_on_invalid_xml()
+    {
+        URL xsd = getClass().getResource("/templates/mocking-templates.xsd");
+        assertNotNull(xsd);
+
+        XmlTemplateDefinitionReader reader = new XmlTemplateDefinitionReader(xsd);
+
+        String invalidXml = "not xml";
+        InputStream is = new ByteArrayInputStream(invalidXml.getBytes());
+
+        assertThrows(MockingTemplateException.class, () -> reader.read(is));
+    }
+}

--- a/org.moreunit.test/test/org/moreunit/elements/MethodContentProviderTest.java
+++ b/org.moreunit.test/test/org/moreunit/elements/MethodContentProviderTest.java
@@ -1,0 +1,41 @@
+package org.moreunit.elements;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+
+import org.eclipse.jdt.core.IMethod;
+import org.junit.jupiter.api.Test;
+
+public class MethodContentProviderTest
+{
+    @Test
+    public void should_return_methods_as_elements()
+    {
+        IMethod method = mock(IMethod.class);
+        MethodContentProvider provider = new MethodContentProvider(List.of(method));
+
+        Object[] elements = provider.getElements(null);
+
+        assertEquals(1, elements.length);
+        assertNotNull(elements[0]);
+    }
+
+    @Test
+    public void should_return_empty_array_for_empty_list()
+    {
+        MethodContentProvider provider = new MethodContentProvider(List.of());
+
+        assertEquals(0, provider.getElements(null).length);
+    }
+
+    @Test
+    public void dispose_and_input_changed_should_not_throw()
+    {
+        MethodContentProvider provider = new MethodContentProvider(List.of());
+        provider.dispose();
+        provider.inputChanged(null, null, null);
+    }
+}

--- a/org.moreunit.test/test/org/moreunit/preferences/TestTypeConstantsTest.java
+++ b/org.moreunit.test/test/org/moreunit/preferences/TestTypeConstantsTest.java
@@ -1,0 +1,32 @@
+package org.moreunit.preferences;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class TestTypeConstantsTest
+{
+    @Test
+    public void should_have_junit5_test_annotation()
+    {
+        assertEquals("org.junit.jupiter.api.Test", TestTypeConstants.TEST_ANNOTATION.get(PreferenceConstants.TEST_TYPE_VALUE_JUNIT_5));
+    }
+
+    @Test
+    public void should_have_junit4_test_annotation()
+    {
+        assertEquals("org.junit.Test", TestTypeConstants.TEST_ANNOTATION.get(PreferenceConstants.TEST_TYPE_VALUE_JUNIT_4));
+    }
+
+    @Test
+    public void should_have_testng_test_annotation()
+    {
+        assertEquals("org.testng.annotations.Test", TestTypeConstants.TEST_ANNOTATION.get(PreferenceConstants.TEST_TYPE_VALUE_TESTNG));
+    }
+
+    @Test
+    public void should_have_junit5_static_import_base()
+    {
+        assertEquals("org.junit.jupiter.api.Assertions", TestTypeConstants.STATIC_IMPORT_BASE_CLASS.get(PreferenceConstants.TEST_TYPE_VALUE_JUNIT_5));
+    }
+}

--- a/org.moreunit.test/test/org/moreunit/refactoring/RenameDialogRunnableTest.java
+++ b/org.moreunit.test/test/org/moreunit/refactoring/RenameDialogRunnableTest.java
@@ -1,0 +1,31 @@
+package org.moreunit.refactoring;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IMethod;
+import org.junit.jupiter.api.Test;
+import org.moreunit.elements.ClassTypeFacade;
+
+public class RenameDialogRunnableTest
+{
+    @Test
+    public void constructor_should_store_parameters_and_create_diviner()
+    {
+        ClassTypeFacade javaFile = mock(ClassTypeFacade.class);
+        ICompilationUnit cu = mock(ICompilationUnit.class);
+        when(javaFile.getCompilationUnit()).thenReturn(cu);
+
+        IMethod method = mock(IMethod.class);
+
+        RenameDialogRunnable runnable = new RenameDialogRunnable(javaFile, method, "newName");
+
+        assertEquals(method, runnable.renamedMethod);
+        assertEquals("newName", runnable.newMethodName);
+        assertNotNull(runnable.testMethodDivinerFactory);
+        assertNotNull(runnable.testMethodDiviner);
+    }
+}

--- a/org.moreunit.test/test/org/moreunit/ui/SeparatorElementTest.java
+++ b/org.moreunit.test/test/org/moreunit/ui/SeparatorElementTest.java
@@ -1,0 +1,35 @@
+package org.moreunit.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class SeparatorElementTest
+{
+    @Test
+    public void should_not_provide_element()
+    {
+        assertFalse(new SeparatorElement().provideElement());
+    }
+
+    @Test
+    public void should_throw_on_execute()
+    {
+        assertThrows(UnsupportedOperationException.class, () -> new SeparatorElement().execute());
+    }
+
+    @Test
+    public void should_have_no_image()
+    {
+        assertNull(new SeparatorElement().getImage());
+    }
+
+    @Test
+    public void should_have_separator_text()
+    {
+        assertEquals("_________________", new SeparatorElement().getText());
+    }
+}


### PR DESCRIPTION
4 new unit tests:\n- XmlTemplateDefinitionReader: valid/invalid XML parsing (2 tests)\n- FileMatcher: constructor stores parameters (1 test)\n- SeparatorElement: provideElement, execute, image, text (4 tests)\n- TestTypeConstants: JUnit5/JUnit4/TestNG annotations and import base (4 tests)