### PR TITLE
test: improve coverage for core.util classes

### DIFF
--- a/org.moreunit.core.test/src/org/moreunit/core/util/FeaturesTest.java
+++ b/org.moreunit.core.test/src/org/moreunit/core/util/FeaturesTest.java
@@ -1,0 +1,34 @@
+package org.moreunit.core.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class FeaturesTest {
+
+    private static final String FEATURE_NAME = "org.moreunit.test.feature";
+
+    @AfterEach
+    void tearDown() {
+        System.clearProperty(FEATURE_NAME);
+    }
+
+    @Test
+    void testIsActiveTrue() {
+        System.setProperty(FEATURE_NAME, "true");
+        assertThat(Features.isActive(FEATURE_NAME)).isTrue();
+    }
+
+    @Test
+    void testIsActiveFalse() {
+        System.setProperty(FEATURE_NAME, "false");
+        assertThat(Features.isActive(FEATURE_NAME)).isFalse();
+    }
+
+    @Test
+    void testIsActiveDefault() {
+        // Property is not set
+        assertThat(Features.isActive(FEATURE_NAME)).isFalse();
+    }
+}

--- a/org.moreunit.core.test/src/org/moreunit/core/util/LRUCacheTest.java
+++ b/org.moreunit.core.test/src/org/moreunit/core/util/LRUCacheTest.java
@@ -1,0 +1,43 @@
+package org.moreunit.core.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class LRUCacheTest {
+
+    @Test
+    void testEvictsEldestEntry() {
+        LRUCache<String, String> cache = new LRUCache<>(3);
+
+        cache.put("key1", "value1");
+        cache.put("key2", "value2");
+        cache.put("key3", "value3");
+
+        assertThat(cache.size()).isEqualTo(3);
+        assertThat(cache.containsKey("key1")).isTrue();
+        assertThat(cache.containsKey("key2")).isTrue();
+        assertThat(cache.containsKey("key3")).isTrue();
+
+        // This should cause key1 to be evicted
+        cache.put("key4", "value4");
+
+        assertThat(cache.size()).isEqualTo(3);
+        assertThat(cache.containsKey("key1")).isFalse();
+        assertThat(cache.containsKey("key2")).isTrue();
+        assertThat(cache.containsKey("key3")).isTrue();
+        assertThat(cache.containsKey("key4")).isTrue();
+
+        // Access key2 so it becomes the most recently used
+        cache.get("key2");
+
+        // This should cause key3 to be evicted (as it's now the least recently used)
+        cache.put("key5", "value5");
+
+        assertThat(cache.size()).isEqualTo(3);
+        assertThat(cache.containsKey("key3")).isFalse();
+        assertThat(cache.containsKey("key2")).isTrue();
+        assertThat(cache.containsKey("key4")).isTrue();
+        assertThat(cache.containsKey("key5")).isTrue();
+    }
+}

--- a/org.moreunit.core.test/src/org/moreunit/core/util/ObjectsTest.java
+++ b/org.moreunit.core.test/src/org/moreunit/core/util/ObjectsTest.java
@@ -1,0 +1,50 @@
+package org.moreunit.core.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+class ObjectsTest {
+
+    @Test
+    void testEqual() {
+        // Same reference
+        String str = "test";
+        assertThat(Objects.equal(str, str)).isTrue();
+
+        // Equal values
+        assertThat(Objects.equal(new String("test"), new String("test"))).isTrue();
+
+        // Both null
+        assertThat(Objects.equal(null, null)).isTrue();
+    }
+
+    @Test
+    void testNotEqual() {
+        // One null
+        assertThat(Objects.equal("test", null)).isFalse();
+        assertThat(Objects.equal(null, "test")).isFalse();
+
+        // Different values
+        assertThat(Objects.equal("test", "test2")).isFalse();
+        assertThat(Objects.equal(1, 2)).isFalse();
+
+        // Different types
+        assertThat(Objects.equal("1", 1)).isFalse();
+    }
+
+    @Test
+    void testHash() {
+        Object obj1 = "test";
+        Object obj2 = 123;
+        Object obj3 = null;
+
+        assertThat(Objects.hash(obj1, obj2, obj3)).isEqualTo(Arrays.hashCode(new Object[] { obj1, obj2, obj3 }));
+
+        assertThat(Objects.hash(obj1)).isEqualTo(Arrays.hashCode(new Object[] { obj1 }));
+
+        assertThat(Objects.hash()).isEqualTo(Arrays.hashCode(new Object[0]));
+    }
+}

--- a/org.moreunit.core.test/src/org/moreunit/core/util/StringLengthComparatorTest.java
+++ b/org.moreunit.core.test/src/org/moreunit/core/util/StringLengthComparatorTest.java
@@ -1,0 +1,25 @@
+package org.moreunit.core.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class StringLengthComparatorTest {
+
+    private final StringLengthComparator comparator = new StringLengthComparator();
+
+    @Test
+    void testCompareShorterWithLonger() {
+        assertThat(comparator.compare("a", "abc")).isNegative();
+    }
+
+    @Test
+    void testCompareLongerWithShorter() {
+        assertThat(comparator.compare("abc", "a")).isPositive();
+    }
+
+    @Test
+    void testCompareEqualLengths() {
+        assertThat(comparator.compare("abc", "def")).isZero();
+    }
+}


### PR DESCRIPTION
This PR improves test coverage for the `org.moreunit.core.util` package by adding unit tests for utility classes that were previously lacking coverage.

### Changes Included:
* Added `LRUCacheTest` to verify correct LRU eviction behavior (when entries exceed `maxSize`, the eldest is removed and MRU status is properly tracked).
* Added `StringLengthComparatorTest` to verify that strings are compared properly based on their length, covering scenarios with shorter vs longer, longer vs shorter, and equal length strings.
* Added `ObjectsTest` to assert behavior of utility methods `equal()` and `hash()`, including safe null handling, equal values, and hashcode generation for multiple objects.
* Added `FeaturesTest` to ensure feature toggle configurations based on system properties resolve correctly (true, false, default). 

### Validation:
* Tested classes: `LRUCache`, `StringLengthComparator`, `Objects`, `Features`.
* Covered edge cases such as null-safety (e.g. `Objects.equal(null, null)`), eldest eviction order when fetching cached elements, and default system property evaluation.
* Executed Maven `xvfb-run -a mvn -f org.moreunit.build/pom.xml test` build successfully locally with all tests passing and no regressions introduced. No mocking was required since all logic involves pure unit logic.

---
*PR created automatically by Jules for task [12283811644484274572](https://jules.google.com/task/12283811644484274572) started by @RoiSoleil*