### PR TITLE
test: add coverage for InMemoryPath and InMemoryResourceContainer

### DIFF
--- a/org.moreunit.core.test/test/org/moreunit/core/resources/InMemoryPathTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/resources/InMemoryPathTest.java
@@ -129,4 +129,26 @@ public class InMemoryPathTest {
             assertEquals(e.getMessage(), "not a relative path");
         }
     }
+
+    @Test
+    public void testIsAbsoluteAndRelative() {
+        InMemoryPath absolutePath = new InMemoryPath("/project/folder");
+        assertTrue(absolutePath.isAbsolute());
+        assertFalse(absolutePath.isRelative());
+
+        InMemoryPath relativePath = new InMemoryPath("folder/file.txt");
+        assertFalse(relativePath.isAbsolute());
+        assertTrue(relativePath.isRelative());
+    }
+
+    @Test
+    public void testIsPrefixOf() {
+        InMemoryPath path1 = new InMemoryPath("/project/folder");
+        InMemoryPath path2 = new InMemoryPath("/project/folder/file.txt");
+        InMemoryPath path3 = new InMemoryPath("/other/folder");
+
+        assertTrue(path1.isPrefixOf(path2));
+        assertTrue(path1.isPrefixOf(path1));
+        assertFalse(path1.isPrefixOf(path3));
+    }
 }

--- a/org.moreunit.core.test/test/org/moreunit/core/resources/InMemoryResourceContainerTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/resources/InMemoryResourceContainerTest.java
@@ -1,0 +1,97 @@
+package org.moreunit.core.resources;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+public class InMemoryResourceContainerTest {
+
+    @Test
+    public void testGetFileAndFolder() {
+        InMemoryWorkspace workspace = new InMemoryWorkspace();
+        InMemoryProject project = workspace.getProject("project");
+
+        File file = project.getFile("folder/file.txt");
+        assertNotNull(file);
+        assertEquals("file.txt", file.getName());
+        assertEquals("/project/folder/file.txt", file.getPath().toString());
+
+        Folder folder = project.getFolder("folder/subfolder");
+        assertNotNull(folder);
+        assertEquals("subfolder", folder.getName());
+        assertEquals("/project/folder/subfolder", folder.getPath().toString());
+    }
+
+    @Test
+    public void testDelete() {
+        InMemoryWorkspace workspace = new InMemoryWorkspace();
+        InMemoryProject project = workspace.getProject("project");
+
+        File file = project.getFile("folder/file.txt");
+        Folder folder = project.getFolder("folder/subfolder");
+
+        file.create();
+        folder.create();
+
+        assertTrue(file.exists());
+        assertTrue(folder.exists());
+
+        project.delete();
+
+        assertFalse(file.exists());
+        assertFalse(folder.exists());
+    }
+
+    @Test
+    public void testListFilesAndFolders() {
+        InMemoryWorkspace workspace = new InMemoryWorkspace();
+        InMemoryProject project = workspace.getProject("project");
+
+        File file1 = project.getFile("file1.txt");
+        file1.create();
+        File file2 = project.getFile("file2.txt");
+        // file2 not created
+
+        Folder folder1 = project.getFolder("folder1");
+        folder1.create();
+        Folder folder2 = project.getFolder("folder2");
+        // folder2 not created
+
+        List<File> files = project.listFiles();
+        assertEquals(1, files.size());
+        assertTrue(files.contains(file1));
+
+        List<Folder> folders = project.listFolders();
+        assertEquals(1, folders.size());
+        assertTrue(folders.contains(folder1));
+    }
+
+    @Test
+    public void testIsParentOf() {
+        InMemoryWorkspace workspace = new InMemoryWorkspace();
+        InMemoryProject project = workspace.getProject("project");
+
+        File file = project.getFile("folder/file.txt");
+
+        assertTrue(project.isParentOf(file));
+
+        InMemoryProject otherProject = workspace.getProject("otherProject");
+        assertFalse(otherProject.isParentOf(file));
+    }
+
+    @Test
+    public void testCreateWithRecord() {
+        InMemoryWorkspace workspace = new InMemoryWorkspace();
+        InMemoryProject project = workspace.getProject("project");
+        Folder folder = project.getFolder("folder1/folder2");
+
+        ContainerCreationRecord record = folder.createWithRecord();
+        assertTrue(folder.exists());
+        assertNotNull(record);
+    }
+}


### PR DESCRIPTION
This PR adds missing unit tests to `InMemoryPathTest.java` and creates a new test class `InMemoryResourceContainerTest.java` to improve coverage for `InMemoryPath` and `InMemoryResourceContainer` respectively. These are core components in `org.moreunit.core.test` module. The new tests verify path manipulation, container creation, file/folder listing and validation. All tests are verified to pass.

---
*PR created automatically by Jules for task [12001933379665216287](https://jules.google.com/task/12001933379665216287) started by @RoiSoleil*