### PR TITLE
test: improve coverage for matching package

### DIFF
--- a/org.moreunit.core.test/src/org/moreunit/core/matching/FileMatchCollectorTest.java
+++ b/org.moreunit.core.test/src/org/moreunit/core/matching/FileMatchCollectorTest.java
@@ -1,0 +1,101 @@
+package org.moreunit.core.matching;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import java.util.Set;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.CoreException;
+import org.junit.jupiter.api.Test;
+
+class FileMatchCollectorTest {
+
+    @Test
+    void testAcceptFile_SearchNotOver_Matches() throws CoreException {
+        SourceFolderPath srcFolder = mock(SourceFolderPath.class);
+        when(srcFolder.isResolved()).thenReturn(true);
+        when(srcFolder.matches(any(IFile.class))).thenReturn(true);
+
+        TestFileMatchCollector collector = new TestFileMatchCollector(srcFolder, false);
+        IFile mockFile = mock(IFile.class);
+
+        boolean result = collector.acceptFile(mockFile);
+
+        assertThat(result).isFalse();
+        assertThat(collector.getResults()).containsExactly(mockFile);
+        assertThat(collector.isMatchFoundCalled()).isTrue();
+    }
+
+    @Test
+    void testAcceptFile_SearchNotOver_DoesNotMatch() throws CoreException {
+        SourceFolderPath srcFolder = mock(SourceFolderPath.class);
+        when(srcFolder.isResolved()).thenReturn(true);
+        when(srcFolder.matches(any(IFile.class))).thenReturn(false);
+
+        TestFileMatchCollector collector = new TestFileMatchCollector(srcFolder, false);
+        IFile mockFile = mock(IFile.class);
+
+        boolean result = collector.acceptFile(mockFile);
+
+        assertThat(result).isFalse();
+        assertThat(collector.getResults()).isEmpty();
+        assertThat(collector.isMatchFoundCalled()).isFalse();
+    }
+
+    @Test
+    void testAcceptFile_SearchIsOver() throws CoreException {
+        SourceFolderPath srcFolder = mock(SourceFolderPath.class);
+        when(srcFolder.isResolved()).thenReturn(true);
+
+        TestFileMatchCollector collector = new TestFileMatchCollector(srcFolder, true);
+        IFile mockFile = mock(IFile.class);
+
+        boolean result = collector.acceptFile(mockFile);
+
+        assertThat(result).isTrue();
+        assertThat(collector.getResults()).isEmpty();
+        assertThat(collector.isMatchFoundCalled()).isFalse();
+    }
+
+    @Test
+    void testAcceptFile_UnresolvedFolder_Matches() throws CoreException {
+        SourceFolderPath srcFolder = mock(SourceFolderPath.class);
+        when(srcFolder.isResolved()).thenReturn(false);
+        // when folder is not resolved, checkFolder is true, so it checks srcFolder.matches(file)
+        when(srcFolder.matches(any(IFile.class))).thenReturn(true);
+
+        TestFileMatchCollector collector = new TestFileMatchCollector(srcFolder, false);
+        IFile mockFile = mock(IFile.class);
+
+        boolean result = collector.acceptFile(mockFile);
+
+        assertThat(result).isFalse();
+        assertThat(collector.getResults()).containsExactly(mockFile);
+        assertThat(collector.isMatchFoundCalled()).isTrue();
+    }
+
+    private static class TestFileMatchCollector extends FileMatchCollector {
+        private final boolean searchOver;
+        private boolean matchFoundCalled = false;
+
+        protected TestFileMatchCollector(SourceFolderPath correspondingSrcFolder, boolean searchOver) {
+            super(correspondingSrcFolder);
+            this.searchOver = searchOver;
+        }
+
+        @Override
+        protected boolean searchIsOver() {
+            return searchOver;
+        }
+
+        @Override
+        protected void matchFound(IFile file) {
+            matchFoundCalled = true;
+        }
+
+        public boolean isMatchFoundCalled() {
+            return matchFoundCalled;
+        }
+    }
+}

--- a/org.moreunit.core.test/src/org/moreunit/core/matching/MatchResultTest.java
+++ b/org.moreunit.core.test/src/org/moreunit/core/matching/MatchResultTest.java
@@ -1,0 +1,102 @@
+package org.moreunit.core.matching;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.core.resources.IFile;
+import org.junit.jupiter.api.Test;
+
+class MatchResultTest {
+
+    @Test
+    void testGetUniqueMatchingFile_NoResults() {
+        FileMatchCollector collector = mock(FileMatchCollector.class);
+        when(collector.getResults()).thenReturn(Collections.emptySet());
+        SourceFolderPath srcFolder = mock(SourceFolderPath.class);
+        FileMatchSelector selector = mock(FileMatchSelector.class);
+
+        MatchResult result = new MatchResult(collector, "PreferredFile", srcFolder, selector);
+
+        MatchingFile matchingFile = result.getUniqueMatchingFile();
+        assertThat(matchingFile.isFound()).isFalse();
+        assertThat(matchingFile.getCorrespondingSrcFolder()).isSameAs(srcFolder);
+        assertThat(matchingFile.getExpectedFileName()).isEqualTo("PreferredFile");
+    }
+
+    @Test
+    void testGetUniqueMatchingFile_OneResult() {
+        FileMatchCollector collector = mock(FileMatchCollector.class);
+        IFile mockFile = mock(IFile.class);
+        when(collector.getResults()).thenReturn(Collections.singleton(mockFile));
+        SourceFolderPath srcFolder = mock(SourceFolderPath.class);
+        FileMatchSelector selector = mock(FileMatchSelector.class);
+
+        MatchResult result = new MatchResult(collector, "PreferredFile", srcFolder, selector);
+
+        MatchingFile matchingFile = result.getUniqueMatchingFile();
+        assertThat(matchingFile.isFound()).isTrue();
+        assertThat(matchingFile.getFile()).isSameAs(mockFile);
+    }
+
+    @Test
+    void testGetUniqueMatchingFile_MultipleResults_SelectionExists() {
+        FileMatchCollector collector = mock(FileMatchCollector.class);
+        Set<IFile> results = new HashSet<>();
+        IFile mockFile1 = mock(IFile.class);
+        IFile mockFile2 = mock(IFile.class);
+        results.add(mockFile1);
+        results.add(mockFile2);
+        when(collector.getResults()).thenReturn(results);
+
+        SourceFolderPath srcFolder = mock(SourceFolderPath.class);
+        FileMatchSelector selector = mock(FileMatchSelector.class);
+        MatchSelection selection = MatchSelection.file(mockFile1);
+        when(selector.select(results, null)).thenReturn(selection);
+
+        MatchResult result = new MatchResult(collector, "PreferredFile", srcFolder, selector);
+
+        MatchingFile matchingFile = result.getUniqueMatchingFile();
+        assertThat(matchingFile.isFound()).isTrue();
+        assertThat(matchingFile.getFile()).isSameAs(mockFile1);
+    }
+
+    @Test
+    void testGetUniqueMatchingFile_MultipleResults_NoSelection() {
+        FileMatchCollector collector = mock(FileMatchCollector.class);
+        Set<IFile> results = new HashSet<>();
+        IFile mockFile1 = mock(IFile.class);
+        IFile mockFile2 = mock(IFile.class);
+        results.add(mockFile1);
+        results.add(mockFile2);
+        when(collector.getResults()).thenReturn(results);
+
+        SourceFolderPath srcFolder = mock(SourceFolderPath.class);
+        FileMatchSelector selector = mock(FileMatchSelector.class);
+        MatchSelection selection = MatchSelection.none();
+        when(selector.select(results, null)).thenReturn(selection);
+
+        MatchResult result = new MatchResult(collector, "PreferredFile", srcFolder, selector);
+
+        MatchingFile matchingFile = result.getUniqueMatchingFile();
+        assertThat(matchingFile.isFound()).isFalse();
+        assertThat(matchingFile.isSearchCancelled()).isTrue();
+    }
+
+    @Test
+    void testMatchFound() {
+        FileMatchCollector collector = mock(FileMatchCollector.class);
+        SourceFolderPath srcFolder = mock(SourceFolderPath.class);
+        FileMatchSelector selector = mock(FileMatchSelector.class);
+        MatchResult result = new MatchResult(collector, "PreferredFile", srcFolder, selector);
+
+        when(collector.getResults()).thenReturn(Collections.emptySet());
+        assertThat(result.matchFound()).isFalse();
+
+        when(collector.getResults()).thenReturn(Collections.singleton(mock(IFile.class)));
+        assertThat(result.matchFound()).isTrue();
+    }
+}

--- a/org.moreunit.core.test/src/org/moreunit/core/matching/MatchSelectionTest.java
+++ b/org.moreunit.core.test/src/org/moreunit/core/matching/MatchSelectionTest.java
@@ -1,0 +1,27 @@
+package org.moreunit.core.matching;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.eclipse.core.resources.IFile;
+import org.junit.jupiter.api.Test;
+
+class MatchSelectionTest {
+
+    @Test
+    void testFileSelection() {
+        IFile mockFile = mock(IFile.class);
+        MatchSelection selection = MatchSelection.file(mockFile);
+
+        assertThat(selection.exists()).isTrue();
+        assertThat(selection.get()).isSameAs(mockFile);
+    }
+
+    @Test
+    void testNoneSelection() {
+        MatchSelection selection = MatchSelection.none();
+
+        assertThat(selection.exists()).isFalse();
+        assertThat(selection.get()).isNull();
+    }
+}

--- a/org.moreunit.core.test/src/org/moreunit/core/matching/MatchStrategyTest.java
+++ b/org.moreunit.core.test/src/org/moreunit/core/matching/MatchStrategyTest.java
@@ -1,0 +1,30 @@
+package org.moreunit.core.matching;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+class MatchStrategyTest {
+
+    @Test
+    void testAllMatchesStrategy() {
+        SourceFolderPath folderPath = mock(SourceFolderPath.class);
+        FileMatchCollector collector = MatchStrategy.ALL_MATCHES.createMatchCollector(folderPath);
+
+        assertThat(collector).isNotNull();
+        assertThat(collector.searchIsOver()).isFalse();
+    }
+
+    @Test
+    void testAnyMatchStrategy() {
+        SourceFolderPath folderPath = mock(SourceFolderPath.class);
+        FileMatchCollector collector = MatchStrategy.ANY_MATCH.createMatchCollector(folderPath);
+
+        assertThat(collector).isNotNull();
+        assertThat(collector.searchIsOver()).isFalse();
+
+        collector.matchFound(null);
+        assertThat(collector.searchIsOver()).isTrue();
+    }
+}


### PR DESCRIPTION
This patch introduces JUnit 5 tests for four utility/matching classes in the org.moreunit.core.matching package:
- MatchSelection
- MatchStrategy
- MatchResult
- FileMatchCollector

These tests adhere to the project constraints by using lightweight Mockito mocks and preventing any requirement for a full Eclipse OSGi workbench spin-up.

Tested classes: MatchSelection, MatchStrategy, MatchResult, FileMatchCollector
Newly covered branches: Edge conditions for FileMatchCollector matching depending on unresolved folders, multiple branch scenarios inside MatchResult when selecting files, enum instantiation in MatchStrategy, and null bounds logic inside MatchSelection.
Mocking choice rationale: Mockito was used to mock `IFile` and `SourceFolderPath` to avoid actual workspace filesystem access.

---
*PR created automatically by Jules for task [1991555873679649980](https://jules.google.com/task/1991555873679649980) started by @RoiSoleil*