### PR TITLE
test: fix IllegalAccessError and latent test bugs blocking CI

### DIFF
--- a/org.moreunit.core.test/test/org/moreunit/core/matching/CamelCaseNameTokenizerTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/matching/CamelCaseNameTokenizerTest.java
@@ -41,7 +41,8 @@ public class CamelCaseNameTokenizerTest extends NameTokenizerTestCase
     @Test
     public void should_handle_underscore_and_digit_boundaries() throws Exception
     {
-        assertEquals(Arrays.asList("name_", "With", "123", "Numbers"), tokenizer.tokenize("name_With123Numbers").getTokens());
+        // an underscore is a token boundary on its own
+        assertEquals(Arrays.asList("name", "_", "With", "123", "Numbers"), tokenizer.tokenize("name_With123Numbers").getTokens());
     }
 
     @Test

--- a/org.moreunit.core.test/test/org/moreunit/core/matching/TestFileNamePatternParserTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/matching/TestFileNamePatternParserTest.java
@@ -126,13 +126,14 @@ public class TestFileNamePatternParserTest
 
         // then
         assertTrue(result.success());
-        assertFalse(result.get().prefix().hasAlternatives());
+        assertTrue(result.get().prefix().hasAlternatives());
+        assertEquals(Arrays.asList(""), result.get().prefix().alternatives());
     }
 
     @Test
-    public void should_return_false_when_has_alternatives_is_called_on_no_alternatives() throws Exception
+    public void should_treat_plain_text_prefix_as_single_alternative() throws Exception
     {
-        // given
+        // given: plain text (without parentheses) is parsed as a single alternative
         TestFileNamePatternParser parser = new TestFileNamePatternParser("prefix_${srcFile}", underscoreTokenizer);
 
         // when
@@ -140,7 +141,9 @@ public class TestFileNamePatternParserTest
 
         // then
         assertTrue(result.success());
-        assertFalse(result.get().prefix().hasAlternatives());
+        assertTrue(result.get().prefix().hasAlternatives());
+        assertEquals(Arrays.asList("prefix"), result.get().prefix().alternatives());
+        assertEquals("", result.get().prefix().before());
     }
 
     @Test
@@ -158,9 +161,9 @@ public class TestFileNamePatternParserTest
     }
 
     @Test
-    public void should_parse_escaped_character_correctly_without_alternatives() throws Exception
+    public void should_parse_escaped_character() throws Exception
     {
-        // given
+        // given: escaped text (without parentheses) is parsed as a single alternative
         TestFileNamePatternParser parser = new TestFileNamePatternParser("\\\\prefix${srcFile}", underscoreTokenizer);
 
         // when
@@ -168,7 +171,8 @@ public class TestFileNamePatternParserTest
 
         // then
         assertTrue(result.success());
-        assertEquals("\\prefix", result.get().prefix().before());
+        assertEquals(Arrays.asList("\\prefix"), result.get().prefix().alternatives());
+        assertEquals("", result.get().prefix().before());
     }
 
     @Test

--- a/org.moreunit.core.test/test/org/moreunit/core/resources/EclipseResourceContainerTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/resources/EclipseResourceContainerTest.java
@@ -12,10 +12,8 @@ import static org.mockito.Mockito.never;
 
 import java.util.List;
 
-import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
-import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
@@ -23,30 +21,17 @@ import org.junit.jupiter.api.Test;
 
 public class EclipseResourceContainerTest
 {
-    private static class DummyEclipseResourceContainer extends EclipseResourceContainer
-    {
-        protected DummyEclipseResourceContainer(IContainer container)
-        {
-            super(container);
-        }
-
-        @Override
-        public void create()
-        {
-        }
-    }
-
     @Test
     public void getFile_should_throw_when_folder_already_exists()
     {
-        IContainer platformContainer = mock(IContainer.class);
+        IFolder platformContainer = mock(IFolder.class);
         when(platformContainer.getFullPath()).thenReturn(mock(IPath.class));
 
         IFolder platformFolder = mock(IFolder.class);
         when(platformFolder.exists()).thenReturn(true);
         when(platformContainer.getFolder(any(org.eclipse.core.runtime.Path.class))).thenReturn(platformFolder);
 
-        EclipseResourceContainer container = new DummyEclipseResourceContainer(platformContainer);
+        ResourceContainer container = new EclipseFolder(platformContainer);
 
         assertThrows(ResourceException.class, () -> container.getFile(new InMemoryPath("path/to/file")));
     }
@@ -54,7 +39,7 @@ public class EclipseResourceContainerTest
     @Test
     public void getFile_should_return_eclipse_file_when_folder_does_not_exist()
     {
-        IContainer platformContainer = mock(IContainer.class);
+        IFolder platformContainer = mock(IFolder.class);
         when(platformContainer.getFullPath()).thenReturn(mock(IPath.class));
 
         IFolder platformFolder = mock(IFolder.class);
@@ -65,7 +50,7 @@ public class EclipseResourceContainerTest
         when(platformFile.getFullPath()).thenReturn(mock(IPath.class));
         when(platformContainer.getFile(any(org.eclipse.core.runtime.Path.class))).thenReturn(platformFile);
 
-        EclipseResourceContainer container = new DummyEclipseResourceContainer(platformContainer);
+        ResourceContainer container = new EclipseFolder(platformContainer);
         File file = container.getFile(new InMemoryPath("path/to/file"));
 
         assertTrue(file instanceof EclipseFile);
@@ -74,14 +59,14 @@ public class EclipseResourceContainerTest
     @Test
     public void getFolder_should_throw_when_file_already_exists()
     {
-        IContainer platformContainer = mock(IContainer.class);
+        IFolder platformContainer = mock(IFolder.class);
         when(platformContainer.getFullPath()).thenReturn(mock(IPath.class));
 
         IFile platformFile = mock(IFile.class);
         when(platformFile.exists()).thenReturn(true);
         when(platformContainer.getFile(any(org.eclipse.core.runtime.Path.class))).thenReturn(platformFile);
 
-        EclipseResourceContainer container = new DummyEclipseResourceContainer(platformContainer);
+        ResourceContainer container = new EclipseFolder(platformContainer);
 
         assertThrows(ResourceException.class, () -> container.getFolder(new InMemoryPath("path/to/folder")));
     }
@@ -89,7 +74,7 @@ public class EclipseResourceContainerTest
     @Test
     public void getFolder_should_return_eclipse_folder_when_file_does_not_exist()
     {
-        IContainer platformContainer = mock(IContainer.class);
+        IFolder platformContainer = mock(IFolder.class);
         when(platformContainer.getFullPath()).thenReturn(mock(IPath.class));
 
         IFile platformFile = mock(IFile.class);
@@ -100,7 +85,7 @@ public class EclipseResourceContainerTest
         when(platformFolder.getFullPath()).thenReturn(mock(IPath.class));
         when(platformContainer.getFolder(any(org.eclipse.core.runtime.Path.class))).thenReturn(platformFolder);
 
-        EclipseResourceContainer container = new DummyEclipseResourceContainer(platformContainer);
+        ResourceContainer container = new EclipseFolder(platformContainer);
         Folder folder = container.getFolder(new InMemoryPath("path/to/folder"));
 
         assertTrue(folder instanceof EclipseFolder);
@@ -109,7 +94,7 @@ public class EclipseResourceContainerTest
     @Test
     public void listFiles_should_return_files() throws Exception
     {
-        IContainer platformContainer = mock(IContainer.class);
+        IFolder platformContainer = mock(IFolder.class);
         when(platformContainer.getFullPath()).thenReturn(mock(IPath.class));
 
         IFile file1 = mock(IFile.class);
@@ -121,7 +106,7 @@ public class EclipseResourceContainerTest
         IResource[] members = new IResource[] { file1, folder1, file2 };
         when(platformContainer.members()).thenReturn(members);
 
-        EclipseResourceContainer container = new DummyEclipseResourceContainer(platformContainer);
+        ResourceContainer container = new EclipseFolder(platformContainer);
         List<File> files = container.listFiles();
 
         assertEquals(2, files.size());
@@ -130,7 +115,7 @@ public class EclipseResourceContainerTest
     @Test
     public void listFolders_should_return_folders() throws Exception
     {
-        IContainer platformContainer = mock(IContainer.class);
+        IFolder platformContainer = mock(IFolder.class);
         when(platformContainer.getFullPath()).thenReturn(mock(IPath.class));
 
         IFile file1 = mock(IFile.class);
@@ -142,7 +127,7 @@ public class EclipseResourceContainerTest
         IResource[] members = new IResource[] { folder1, file1, folder2 };
         when(platformContainer.members()).thenReturn(members);
 
-        EclipseResourceContainer container = new DummyEclipseResourceContainer(platformContainer);
+        ResourceContainer container = new EclipseFolder(platformContainer);
         List<Folder> folders = container.listFolders();
 
         assertEquals(2, folders.size());
@@ -151,12 +136,13 @@ public class EclipseResourceContainerTest
     @Test
     public void listResourcesOfType_should_throw_resource_exception_on_error() throws Exception
     {
-        IContainer platformContainer = mock(IContainer.class);
+        IFolder platformContainer = mock(IFolder.class);
         when(platformContainer.getFullPath()).thenReturn(mock(IPath.class));
 
-        when(platformContainer.members()).thenThrow(new CoreException(mock(org.eclipse.core.runtime.IStatus.class)));
+        CoreException coreException = new CoreException(mock(org.eclipse.core.runtime.IStatus.class));
+        when(platformContainer.members()).thenThrow(coreException);
 
-        EclipseResourceContainer container = new DummyEclipseResourceContainer(platformContainer);
+        ResourceContainer container = new EclipseFolder(platformContainer);
 
         assertThrows(ResourceException.class, container::listFiles);
     }

--- a/org.moreunit.core.test/test/org/moreunit/core/resources/EclipseResourceTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/resources/EclipseResourceTest.java
@@ -12,37 +12,22 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.eclipse.core.resources.IContainer;
+import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IPath;
 import org.junit.jupiter.api.Test;
 
 public class EclipseResourceTest
 {
-    private static class DummyEclipseResource extends EclipseResource
-    {
-        protected DummyEclipseResource(IResource resource)
-        {
-            super(resource);
-        }
-
-        @Override
-        public void create()
-        {
-        }
-    }
-
     @Test
     public void delete_should_call_delete_on_underlying_resource() throws Exception
     {
-        IResource underlyingResource = mock(IResource.class);
-        IPath path = mock(IPath.class);
-        when(underlyingResource.getFullPath()).thenReturn(path);
+        IFile underlyingResource = mock(IFile.class);
+        when(underlyingResource.getFullPath()).thenReturn(new org.eclipse.core.runtime.Path("/project/file.txt"));
 
-        EclipseResource resource = new DummyEclipseResource(underlyingResource);
+        Resource resource = new EclipseFile(underlyingResource);
         resource.delete();
 
         verify(underlyingResource).delete(true, null);
@@ -51,42 +36,39 @@ public class EclipseResourceTest
     @Test
     public void delete_should_throw_resource_exception_when_core_exception_occurs() throws Exception
     {
-        IResource underlyingResource = mock(IResource.class);
-        IPath path = mock(IPath.class);
-        when(underlyingResource.getFullPath()).thenReturn(path);
+        IFile underlyingResource = mock(IFile.class);
+        when(underlyingResource.getFullPath()).thenReturn(new org.eclipse.core.runtime.Path("/project/file.txt"));
 
         doThrow(new CoreException(mock(org.eclipse.core.runtime.IStatus.class)))
             .when(underlyingResource).delete(anyBoolean(), any());
 
-        EclipseResource resource = new DummyEclipseResource(underlyingResource);
+        Resource resource = new EclipseFile(underlyingResource);
         assertThrows(ResourceException.class, resource::delete);
     }
 
     @Test
     public void exists_should_delegate_to_underlying_resource()
     {
-        IResource underlyingResource = mock(IResource.class);
-        IPath path = mock(IPath.class);
-        when(underlyingResource.getFullPath()).thenReturn(path);
+        IFile underlyingResource = mock(IFile.class);
+        when(underlyingResource.getFullPath()).thenReturn(new org.eclipse.core.runtime.Path("/project/file.txt"));
 
         when(underlyingResource.exists()).thenReturn(true);
-        EclipseResource resource1 = new DummyEclipseResource(underlyingResource);
+        Resource resource1 = new EclipseFile(underlyingResource);
         assertTrue(resource1.exists());
 
         when(underlyingResource.exists()).thenReturn(false);
-        EclipseResource resource2 = new DummyEclipseResource(underlyingResource);
+        Resource resource2 = new EclipseFile(underlyingResource);
         assertFalse(resource2.exists());
     }
 
     @Test
     public void getParent_should_return_workspace_when_parent_is_null()
     {
-        IResource underlyingResource = mock(IResource.class);
-        IPath path = mock(IPath.class);
-        when(underlyingResource.getFullPath()).thenReturn(path);
+        IFile underlyingResource = mock(IFile.class);
+        when(underlyingResource.getFullPath()).thenReturn(new org.eclipse.core.runtime.Path("/project/file.txt"));
         when(underlyingResource.getParent()).thenReturn(null);
 
-        EclipseResource resource = new DummyEclipseResource(underlyingResource);
+        Resource resource = new EclipseFile(underlyingResource);
         ResourceContainer parent = resource.getParent();
 
         assertTrue(parent instanceof EclipseWorkspace);
@@ -95,14 +77,13 @@ public class EclipseResourceTest
     @Test
     public void getParent_should_return_workspace_when_parent_is_workspace_root()
     {
-        IResource underlyingResource = mock(IResource.class);
-        IPath path = mock(IPath.class);
-        when(underlyingResource.getFullPath()).thenReturn(path);
+        IFile underlyingResource = mock(IFile.class);
+        when(underlyingResource.getFullPath()).thenReturn(new org.eclipse.core.runtime.Path("/project/file.txt"));
 
         IWorkspaceRoot root = mock(IWorkspaceRoot.class);
         when(underlyingResource.getParent()).thenReturn(root);
 
-        EclipseResource resource = new DummyEclipseResource(underlyingResource);
+        Resource resource = new EclipseFile(underlyingResource);
         ResourceContainer parent = resource.getParent();
 
         assertTrue(parent instanceof EclipseWorkspace);
@@ -111,15 +92,14 @@ public class EclipseResourceTest
     @Test
     public void getParent_should_return_project_when_parent_is_project()
     {
-        IResource underlyingResource = mock(IResource.class);
-        IPath path = mock(IPath.class);
-        when(underlyingResource.getFullPath()).thenReturn(path);
+        IFile underlyingResource = mock(IFile.class);
+        when(underlyingResource.getFullPath()).thenReturn(new org.eclipse.core.runtime.Path("/project/file.txt"));
 
         IProject project = mock(IProject.class);
-        when(project.getFullPath()).thenReturn(mock(IPath.class));
+        when(project.getFullPath()).thenReturn(new org.eclipse.core.runtime.Path("/project/parent"));
         when(underlyingResource.getParent()).thenReturn(project);
 
-        EclipseResource resource = new DummyEclipseResource(underlyingResource);
+        Resource resource = new EclipseFile(underlyingResource);
         ResourceContainer parent = resource.getParent();
 
         assertTrue(parent instanceof EclipseProject);
@@ -128,15 +108,14 @@ public class EclipseResourceTest
     @Test
     public void getParent_should_return_folder_when_parent_is_folder()
     {
-        IResource underlyingResource = mock(IResource.class);
-        IPath path = mock(IPath.class);
-        when(underlyingResource.getFullPath()).thenReturn(path);
+        IFile underlyingResource = mock(IFile.class);
+        when(underlyingResource.getFullPath()).thenReturn(new org.eclipse.core.runtime.Path("/project/file.txt"));
 
         IFolder folder = mock(IFolder.class);
-        when(folder.getFullPath()).thenReturn(mock(IPath.class));
+        when(folder.getFullPath()).thenReturn(new org.eclipse.core.runtime.Path("/project/parent"));
         when(underlyingResource.getParent()).thenReturn(folder);
 
-        EclipseResource resource = new DummyEclipseResource(underlyingResource);
+        Resource resource = new EclipseFile(underlyingResource);
         ResourceContainer parent = resource.getParent();
 
         assertTrue(parent instanceof EclipseFolder);
@@ -145,25 +124,23 @@ public class EclipseResourceTest
     @Test
     public void getParent_should_throw_resource_exception_when_parent_is_unknown_type()
     {
-        IResource underlyingResource = mock(IResource.class);
-        IPath path = mock(IPath.class);
-        when(underlyingResource.getFullPath()).thenReturn(path);
+        IFile underlyingResource = mock(IFile.class);
+        when(underlyingResource.getFullPath()).thenReturn(new org.eclipse.core.runtime.Path("/project/file.txt"));
 
         IContainer unknownContainer = mock(IContainer.class);
         when(underlyingResource.getParent()).thenReturn(unknownContainer);
 
-        EclipseResource resource = new DummyEclipseResource(underlyingResource);
+        Resource resource = new EclipseFile(underlyingResource);
         assertThrows(ResourceException.class, resource::getParent);
     }
 
     @Test
     public void getUnderlyingPlatformResource_should_return_the_resource()
     {
-        IResource underlyingResource = mock(IResource.class);
-        IPath path = mock(IPath.class);
-        when(underlyingResource.getFullPath()).thenReturn(path);
+        IFile underlyingResource = mock(IFile.class);
+        when(underlyingResource.getFullPath()).thenReturn(new org.eclipse.core.runtime.Path("/project/file.txt"));
 
-        EclipseResource resource = new DummyEclipseResource(underlyingResource);
+        Resource resource = new EclipseFile(underlyingResource);
         assertEquals(underlyingResource, resource.getUnderlyingPlatformResource());
     }
 }


### PR DESCRIPTION
## Problème

Le build `MoreUnit Build` et `Coverage` échoue sur `master` depuis le commit 8c64822b (`test: improve coverage for core resources`, 25 août).

Cause racine : le runtime de tests plantait **dès la découverte JUnit** (le process OSGi se terminait avec le code -1) à cause d'une `IllegalAccessError` :
- `EclipseResourceContainerTest` et `EclipseResourceTest` définissaient des classes `Dummy` qui **étendent des classes package-private** (`EclipseResourceContainer`, `EclipseResource`) de `org.moreunit.core`.
- `org.moreunit.core.test` est un bundle séparé (pas un fragment), donc en OSGi les deux classes sont chargées par des classloaders différents → accès interdit au niveau JVM.

Comme le runtime mourait avant d'exécuter quoi que ce soit, d'autres bugs latents des tests ajoutés récemment n'avaient jamais pu être détectés.

## Corrections (tests uniquement, aucun changement produit)

1. **Accès package-private** : utiliser les sous-classes publiques `EclipseFolder` / `EclipseFile` avec des mocks `IFolder` / `IFile`, comme le font déjà `EclipseFolderTest` et `EclipseFileTest`.
2. **EclipseResourceTest** : stubber `getFullPath()` avec de vrais `IPath` (`EclipsePath` appelle `removeTrailingSeparator()`, qui renvoie `null` sur un mock → NPE dans `delete()`).
3. **EclipseResourceContainerTest** : créer la `CoreException` (et son mock `IStatus`) **avant** l'appel `when()` pour éviter `UnfinishedStubbingException`.
4. **CamelCaseNameTokenizerTest** : le underscore est une frontière de token à part entière (comportement historique du tokenizer).
5. **TestFileNamePatternParserTest** : un texte simple ou échappé sans groupe `(...)` est parsé comme une alternative unique et `before()` reste vide (comportement historique du parser, déjà documenté par `should_parse_pattern_with_one_prefix`).

## Validation

`org.moreunit.core.test` : **530 tests, 0 échec, 0 erreur** (harness UI, configuration identique à la CI).