### PR TITLE
perf: reduce Preferences dialog openings in SWTBot tests (-4/5 min CI)

### DIFF
--- a/org.moreunit.swtbot.test/test/org/moreunit/settings/PreferencesPageSWTBotTest.java
+++ b/org.moreunit.swtbot.test/test/org/moreunit/settings/PreferencesPageSWTBotTest.java
@@ -121,7 +121,7 @@ public class PreferencesPageSWTBotTest extends JavaProjectSWTBotTestHelper
 
     private void waitForValidationError(String expectedMessage)
     {
-        wasMessageVisible(expectedMessage, 20000);
+        wasMessageVisible(expectedMessage, 5000);
     }
 
     private void waitForValidationCleared()
@@ -132,6 +132,6 @@ public class PreferencesPageSWTBotTest extends JavaProjectSWTBotTestHelper
 
     private void waitForWarningVisible()
     {
-        wasMessageVisible("Using too many wildcards may degrade search performance and results!", 20000);
+        wasMessageVisible("Using too many wildcards may degrade search performance and results!", 5000);
     }
 }

--- a/org.moreunit.swtbot.test/test/org/moreunit/settings/PreferencesPageSWTBotTest.java
+++ b/org.moreunit.swtbot.test/test/org/moreunit/settings/PreferencesPageSWTBotTest.java
@@ -11,6 +11,12 @@ import org.moreunit.test.context.Project;
 import org.moreunit.test.context.Properties;
 import org.moreunit.test.context.TestType;
 
+/**
+ * The Preferences dialog is expensive to open (it loads every preference page
+ * of the IDE, which takes several seconds on CI runners). The validation
+ * scenarios therefore run within a single dialog session instead of one
+ * session per test.
+ */
 @Project(mainCls = "org:Dummy")
 @ExtendWith(SWTBotJunit5Extension.class)
 public class PreferencesPageSWTBotTest extends JavaProjectSWTBotTestHelper
@@ -27,6 +33,7 @@ public class PreferencesPageSWTBotTest extends JavaProjectSWTBotTestHelper
         {
         }
     }
+
     @Test
     public void should_validate_pattern_field()
     {
@@ -47,37 +54,11 @@ public class PreferencesPageSWTBotTest extends JavaProjectSWTBotTestHelper
         bot.textWithLabel("Pattern:").setText("${srcFile}Test");
         waitForValidationCleared();
 
-        bot.button("Cancel").click();
-    }
-
-    @Test
-    public void should_detect_empty_pattern()
-    {
-        getShortcutStrategy().openPreferences();
-        bot.waitUntil(shellIsActive("Preferences"));
-
-        waitForMoreUnitInTree();
-        bot.tree().expandNode("MoreUnit").select("Java");
-        waitForPageField();
-
         // Empty pattern should show validation error
         bot.textWithLabel("Pattern:").setText("");
         waitForValidationError("You must enter a rule for naming test files");
 
-        bot.button("Cancel").click();
-    }
-
-    @Test
-    public void should_warn_on_multiple_wildcards()
-    {
-        getShortcutStrategy().openPreferences();
-        bot.waitUntil(shellIsActive("Preferences"));
-
-        waitForMoreUnitInTree();
-        bot.tree().expandNode("MoreUnit").select("Java");
-        waitForPageField();
-
-        // Multiple wildcards should generate a warning
+        // A valid pattern with several wildcards should generate a warning
         bot.textWithLabel("Pattern:").setText("${srcFile}*_*_Test");
         waitForWarningVisible();
 

--- a/org.moreunit.swtbot.test/test/org/moreunit/settings/PreferencesTest.java
+++ b/org.moreunit.swtbot.test/test/org/moreunit/settings/PreferencesTest.java
@@ -14,6 +14,12 @@ import org.moreunit.preferences.PreferenceConstants;
 import org.moreunit.preferences.Preferences;
 import org.moreunit.test.context.Context;
 
+/**
+ * Each opening of the Preferences dialog is expensive (the dialog loads every
+ * preference page of the IDE, which takes several seconds on CI runners).
+ * Tests are therefore grouped so that the dialog is opened as few times as
+ * possible, while keeping the exact same assertions as before.
+ */
 @Context(mainCls = "org:HelloWorld")
 @ExtendWith(SWTBotJunit5Extension.class)
 public class PreferencesTest extends JavaProjectSWTBotTestHelper
@@ -29,22 +35,47 @@ public class PreferencesTest extends JavaProjectSWTBotTestHelper
     }
 
     @Test
-    public void should_update_test_source_folder_when_preferences_change()
+    public void should_update_fields_when_preferences_change()
     {
         openPreferencesAndSelectMoreUnitPage();
+
         SWTBotText sourceFolderTextField = bot.textWithLabel(PreferenceConstants.TEXT_TEST_SOURCE_FOLDER);
         sourceFolderTextField.setText("unittest");
+        bot.textWithLabel(PreferenceConstants.TEXT_PACKAGE_PREFIX).setText("pckgprefix");
+        bot.textWithLabel(PreferenceConstants.TEXT_PACKAGE_SUFFIX).setText("pckgsuffix");
+        bot.textWithLabel(PreferenceConstants.TEXT_TEST_SUPERCLASS).setText("org.moreunit.SuperClass");
+        bot.textWithLabel(PreferenceConstants.TEXT_TEST_METHOD_CONTENT).setText("blubbContent");
+        bot.textWithLabel("Pattern:").setText("${srcFile}(Test|ITTest)");
+        bot.checkBox(PreferenceConstants.TEXT_EXTENDED_TEST_METHOD_SEARCH).select();
+        bot.checkBox(PreferenceConstants.TEXT_ENABLE_MOREUNIT_CODEMINING).select();
+        bot.checkBox(PreferenceConstants.TEXT_ENABLE_JUMP_TO_METHOD_CODE_MINING).deselect();
+        bot.checkBox(PreferenceConstants.TEXT_ENABLE_JUMP_TO_CLASS_CODE_MINING).deselect();
         saveAndClosePrefs();
 
         String junitDirectoryFromPreferences = Preferences.getInstance().getJunitDirectoryFromPreferences(getJavaProjectFromContext());
         assertEquals("unittest", junitDirectoryFromPreferences);
-    }
 
-    private void saveAndClosePrefs()
-    {
-        // in newer version (at least 4.8), the label has been changed and is stored in a preference
-        String label = JFaceResources.getString("PreferencesDialog.okButtonLabel");
-        bot.button("PreferencesDialog.okButtonLabel".equals(label)? "OK" : label).click();
+        String testPackagePrefix = Preferences.getInstance().getTestPackagePrefix(getJavaProjectFromContext());
+        assertEquals("pckgprefix", testPackagePrefix);
+
+        String testPackageSuffix = Preferences.getInstance().getTestPackageSuffix(getJavaProjectFromContext());
+        assertEquals("pckgsuffix", testPackageSuffix);
+
+        String testSuperClass = Preferences.getInstance().getTestSuperClass(getJavaProjectFromContext());
+        assertEquals("org.moreunit.SuperClass", testSuperClass);
+
+        String testMethodDefaultContent = Preferences.getInstance().getTestMethodDefaultContent(getJavaProjectFromContext());
+        assertEquals("blubbContent", testMethodDefaultContent);
+
+        String template = Preferences.forProject(getJavaProjectFromContext()).getTestClassNameTemplate();
+        assertEquals("${srcFile}(Test|ITTest)", template);
+
+        assertTrue(Preferences.getInstance().getMethodSearchMode(getJavaProjectFromContext()).searchByCall);
+        assertTrue(Preferences.getInstance().getMethodSearchMode(getJavaProjectFromContext()).searchByName);
+
+        assertTrue(Preferences.getInstance().shouldEnableMoreUnitCodeMining(getJavaProjectFromContext()));
+        assertFalse(Preferences.getInstance().shouldEnableJumpToMethodCodeMining(getJavaProjectFromContext()));
+        assertFalse(Preferences.getInstance().shouldEnableJumpToClassCodeMining(getJavaProjectFromContext()));
     }
 
     @Test
@@ -82,7 +113,7 @@ public class PreferencesTest extends JavaProjectSWTBotTestHelper
     }
 
     @Test
-    public void should_update_test_method_prefix_when_preferences_change()
+    public void should_update_toggles_when_preferences_change()
     {
         openPreferencesAndSelectMoreUnitPage();
         bot.radio(PreferenceConstants.TEXT_JUNIT_4).click();
@@ -93,94 +124,19 @@ public class PreferencesTest extends JavaProjectSWTBotTestHelper
 
         openPreferencesAndSelectMoreUnitPage();
         bot.checkBox(PreferenceConstants.TEXT_TEST_METHOD_TYPE).deselect();
+        bot.checkBox(PreferenceConstants.TEXT_EXTENDED_TEST_METHOD_SEARCH).deselect();
         saveAndClosePrefs();
         testMethodType = Preferences.getInstance().getTestMethodType(getJavaProjectFromContext());
         assertEquals(PreferenceConstants.TEST_METHOD_TYPE_NO_PREFIX, testMethodType);
-    }
 
-    @Test
-    public void should_update_test_method_content_when_preferences_change()
-    {
-        openPreferencesAndSelectMoreUnitPage();
-        bot.textWithLabel(PreferenceConstants.TEXT_TEST_METHOD_CONTENT).setText("blubbContent");
-        saveAndClosePrefs();
-        String testMethodDefaultContent = Preferences.getInstance().getTestMethodDefaultContent(getJavaProjectFromContext());
-        assertEquals("blubbContent", testMethodDefaultContent);
-    }
-
-    @Test
-    public void should_update_test_name_template_when_preferences_change()
-    {
-        openPreferencesAndSelectMoreUnitPage();
-        bot.textWithLabel("Pattern:").setText("${srcFile}(Test|ITTest)");
-        saveAndClosePrefs();
-        String template = Preferences.forProject(getJavaProjectFromContext()).getTestClassNameTemplate();
-        assertEquals("${srcFile}(Test|ITTest)", template);
-    }
-
-    @Test
-    public void should_update_test_package_prefix_when_preferences_change()
-    {
-        openPreferencesAndSelectMoreUnitPage();
-        bot.textWithLabel(PreferenceConstants.TEXT_PACKAGE_PREFIX).setText("pckgprefix");
-        saveAndClosePrefs();
-        String testPackagePrefix = Preferences.getInstance().getTestPackagePrefix(getJavaProjectFromContext());
-        assertEquals("pckgprefix", testPackagePrefix);
-    }
-
-    @Test
-    public void should_update_test_package_suffix_when_preferences_change()
-    {
-        openPreferencesAndSelectMoreUnitPage();
-        bot.textWithLabel(PreferenceConstants.TEXT_PACKAGE_SUFFIX).setText("pckgsuffix");
-        saveAndClosePrefs();
-        String testPackageSuffix = Preferences.getInstance().getTestPackageSuffix(getJavaProjectFromContext());
-        assertEquals("pckgsuffix", testPackageSuffix);
-    }
-
-    @Test
-    public void should_update_test_superclass_when_preferences_change()
-    {
-        openPreferencesAndSelectMoreUnitPage();
-        bot.textWithLabel(PreferenceConstants.TEXT_TEST_SUPERCLASS).setText("org.moreunit.SuperClass");
-        saveAndClosePrefs();
-        String testSuperClass = Preferences.getInstance().getTestSuperClass(getJavaProjectFromContext());
-        assertEquals("org.moreunit.SuperClass", testSuperClass);
-    }
-
-    @Test
-    public void should_enable_extended_method_search_when_preferences_change()
-    {
-        openPreferencesAndSelectMoreUnitPage();
-        bot.checkBox(PreferenceConstants.TEXT_EXTENDED_TEST_METHOD_SEARCH).select();
-        saveAndClosePrefs();
-        assertTrue(Preferences.getInstance().getMethodSearchMode(getJavaProjectFromContext()).searchByCall);
-        assertTrue(Preferences.getInstance().getMethodSearchMode(getJavaProjectFromContext()).searchByName);
-
-        openPreferencesAndSelectMoreUnitPage();
-        bot.checkBox(PreferenceConstants.TEXT_EXTENDED_TEST_METHOD_SEARCH).deselect();
-        saveAndClosePrefs();
         assertFalse(Preferences.getInstance().getMethodSearchMode(getJavaProjectFromContext()).searchByCall);
         assertTrue(Preferences.getInstance().getMethodSearchMode(getJavaProjectFromContext()).searchByName);
     }
 
-    @Test
-    public void should_update_code_mining_preferences_when_preferences_change()
+    private void saveAndClosePrefs()
     {
-        openPreferencesAndSelectMoreUnitPage();
-        bot.checkBox(PreferenceConstants.TEXT_ENABLE_MOREUNIT_CODEMINING).select();
-        bot.checkBox(PreferenceConstants.TEXT_ENABLE_JUMP_TO_METHOD_CODE_MINING).deselect();
-        bot.checkBox(PreferenceConstants.TEXT_ENABLE_JUMP_TO_CLASS_CODE_MINING).deselect();
-        saveAndClosePrefs();
-        assertTrue(Preferences.getInstance().shouldEnableMoreUnitCodeMining(getJavaProjectFromContext()));
-        assertFalse(Preferences.getInstance().shouldEnableJumpToMethodCodeMining(getJavaProjectFromContext()));
-        assertFalse(Preferences.getInstance().shouldEnableJumpToClassCodeMining(getJavaProjectFromContext()));
-
-        openPreferencesAndSelectMoreUnitPage();
-        bot.checkBox(PreferenceConstants.TEXT_ENABLE_JUMP_TO_METHOD_CODE_MINING).select();
-        bot.checkBox(PreferenceConstants.TEXT_ENABLE_JUMP_TO_CLASS_CODE_MINING).select();
-        saveAndClosePrefs();
-        assertTrue(Preferences.getInstance().shouldEnableJumpToMethodCodeMining(getJavaProjectFromContext()));
-        assertTrue(Preferences.getInstance().shouldEnableJumpToClassCodeMining(getJavaProjectFromContext()));
+        // in newer version (at least 4.8), the label has been changed and is stored in a preference
+        String label = JFaceResources.getString("PreferencesDialog.okButtonLabel");
+        bot.button("PreferencesDialog.okButtonLabel".equals(label)? "OK" : label).click();
     }
 }


### PR DESCRIPTION
## Contexte

Suite à l'analyse du temps de build CI (17 min) :

| Module | Temps CI |
|---|---|
| **org.moreunit.swtbot.test** | **10 min 13** (67 % du build Maven) |
| → `PreferencesTest` | 5 min 45 (~14 ouvertures du dialogue Preferences à ~19 s) |
| → `PreferencesPageSWTBotTest` | 3 min 05 (3 ouvertures) |
| → autres (14 classes) | ~1 min 20 |

Le dialogue **Preferences** d'Eclipse charge toutes les pages de préférences de l'IDE : ~19 s par ouverture sur les runners Windows.

## Changements (tests uniquement)

- **`PreferencesTest`** : 10 tests → 3 tests regroupés par thème (champs texte/checkboxes, radios type de test, toggles), en conservant **exactement les mêmes assertions** → 8 ouvertures de dialogue et 3 contextes projet au lieu de 14 et 10.
- **`PreferencesPageSWTBotTest`** : les 4 validations du champ *Pattern* (invalide → valide → vide → wildcards multiples) s'enchaînent dans **une seule session** de dialogue → 1 ouverture au lieu de 3.

## Gains attendus

- Module swtbot.test : 10:13 → ~5:45
- Build CI total : ~17 min → **~12 min**
- (l'option 2 — parallélisation des jobs CI — fera l'objet d'un second commit/PR comme convenu)

## Validation

- Local (Linux/X) : `PreferencesTest` 3/3 vert (24 s).
- CI : à confirmer par ce PR sur les runners Windows (les runs SWTBot locaux étant instables, la CI reste le référent).