### PR TITLE
docs(skills): Tycho 5 gotchas & CI/SWTBot performance knowledge

### DIFF
--- a/.claude/skills/moreunit-build/SKILL.md
+++ b/.claude/skills/moreunit-build/SKILL.md
@@ -125,6 +125,29 @@ Share the rest (e.g. common Maven flags) via a workflow-level `env:` (like
 into the shell command line, and bash/pwsh do not re-parse quotes inside
 expanded variables.
 
+### Windows runners: pwsh splits unquoted -D arguments at the dot
+
+On `windows-latest`, `run:` defaults to **PowerShell (pwsh)**, which splits an
+unquoted argument at the first `.`:
+
+```
+-Dtarget.platform.classifier=eclipse-latest
+  → passed to Maven as:  -Dtarget   .platform.classifier=eclipse-latest
+  → "Unknown lifecycle phase .platform.classifier=eclipse-latest"
+```
+
+Fix: set the workflow default shell to bash (preinstalled on Windows runners):
+
+```yaml
+defaults:
+  run:
+    shell: bash
+```
+
+Then unquoted expansions (like `MVN_ARGS`) work without quoting each `-D`
+flag individually. (The historical workflow quoted every -D flag for exactly
+this reason.)
+
 
 Measured on master builds (useful when optimizing CI time):
 

--- a/.claude/skills/moreunit-build/SKILL.md
+++ b/.claude/skills/moreunit-build/SKILL.md
@@ -52,6 +52,69 @@ mvn -o -pl ../org.moreunit.swtbot.test -am verify -Dtest=RunTestSWTBotTest -fae
 
 The `-Dtest=` filter applies Tycho-surefire's `test` parameter. Upstream modules with no matching class gracefully skip (0 tests).
 
+## Tycho 5 gotchas (verified experimentally, 2026-09)
+
+### Surefire binds to `integration-test`, not `test`
+
+With Tycho 5, `tycho-surefire:test` is bound to the **`integration-test` phase**:
+
+```bash
+mvn -o test -pl ../org.moreunit.swtbot.test   # ⚠️ BUILD SUCCESS but NO tests run (silent!)
+mvn -o verify -pl ../org.moreunit.swtbot.test # ✅ runs the tests
+```
+
+A `mvn test` that succeeds in a few seconds without any `Tests run:` line is a red flag: the tests were silently skipped.
+
+### `-pl` selectors must use the right groupId
+
+Test/product modules use **two different groupIds** — a wrong groupId fails with `Could not find the selected project in the reactor`:
+
+- `org.moreunit` → `org.moreunit.core`, `org.moreunit.core.test`, `org.moreunit.test.dependencies`? no → **`org.moreunit` group only for core + core.test + the aggregator**
+- `org.moreunit.plugins` → `org.moreunit` (plugin, dir `org.moreunit.plugin`), `org.moreunit.mock`, `org.moreunit.mock.test`, `org.moreunit.mock.it`, `org.moreunit.test`, `org.moreunit.test.dependencies`, `org.moreunit.swtbot.test`
+
+Example: `mvn -pl org.moreunit.plugins:org.moreunit.swtbot.test verify`
+
+### Tycho resolves `Require-Bundle` from the target platform, not from Maven reactor deps
+
+`-am` for a test module pulls **almost nothing**: `mvn -pl org.moreunit.plugins:org.moreunit.swtbot.test -am validate` = parent + swtbot.test only. To run a single test module in isolation, the product bundles it requires must already be **installed in the local repo**:
+
+```bash
+# 1. install the product bundles required by the test module (tests skipped)
+mvn -o install -DskipTests -pl org.moreunit:org.moreunit.core,org.moreunit.plugins:org.moreunit,org.moreunit.plugins:org.moreunit.test.dependencies
+# 2. run the test module alone (Tycho resolves Require-Bundle from installed local artifacts)
+mvn -o verify -pl org.moreunit.plugins:org.moreunit.swtbot.test -Dtarget.platform.classifier=eclipse-latest
+```
+
+- Tycho includes locally installed artifacts (`~/.m2/repository/...`) in the target platform by default (verified: step 2 works in offline mode after step 1).
+- `-DskipTests` **is** respected by tycho-surefire (verified) — useful for the step 1 above.
+
+### Running a single module while excluding test modules from a full reactor
+
+Exclusions are useful to skip unwanted test modules in one pass (Maven ≥3.2 syntax):
+
+```bash
+mvn clean install -pl '!org.moreunit.plugins:org.moreunit.swtbot.test'        # everything but swtbot
+mvn clean install -pl '!org.moreunit:org.moreunit.core.test,!org.moreunit:org.moreunit.test,!org.moreunit.plugins:org.moreunit.mock.test,!org.moreunit.plugins:org.moreunit.mock.it'  # product + swtbot only
+```
+
+### Run a single SWTBot test class in isolation (validation recipe)
+
+Full-module SWTBot runs are unstable on a shared desktop display (workbench dies mid-run → cascading `activeShell is null` / `Workspace is already closed` errors, even on unmodified code). For A/B test validation, run **one class at a time**:
+
+```bash
+mvn -o -pl ../org.moreunit.swtbot.test verify -Dtest='PreferencesTest' -Dmaven.test.failure.ignore=true
+```
+
+## CI performance knowledge (GitHub Actions, windows-latest runners)
+
+Measured on master builds (useful when optimizing CI time):
+
+- Full build ≈ 15 min Maven; `org.moreunit.swtbot.test` ≈ **10:30 (≈ 2/3 of the build)**.
+- SWTBot cost breakdown: opening the Eclipse **Preferences dialog ≈ 19 s per opening** on Windows CI (it loads every preference page of the IDE). `PreferencesTest`/`PreferencesPageSWTBotTest` were the worst offenders — group preference changes into few dialog sessions (see PR #370: swtbot 10:30 → 6:45).
+- The Preferences **Properties** dialog (project-scoped) is much cheaper (~1 s/opening).
+- Module timings are in the job log under `Reactor Summary` (`SUCCESS [XX s]` lines) and per-test `Time elapsed`; parse the job log with `gh api repos/<org>/<repo>/actions/jobs/<job-id>/logs`.
+- Full SWTBot module runs are flaky on CI too; prefer class-level runs for diagnosis.
+
 ## UI / headless execution matrix
 
 | Module | Needs display? | Needs Workbench? | Default UI harness | How to run |

--- a/.claude/skills/moreunit-build/SKILL.md
+++ b/.claude/skills/moreunit-build/SKILL.md
@@ -107,6 +107,25 @@ mvn -o -pl ../org.moreunit.swtbot.test verify -Dtest='PreferencesTest' -Dmaven.t
 
 ## CI performance knowledge (GitHub Actions, windows-latest runners)
 
+### Composite actions: checkout comes first
+
+A **local composite action cannot contain the checkout step** — the repo must
+already be checked out for the action to be found (`Can't find 'action.yml'
+... Did you forget to run actions/checkout before running your local action?`).
+Pattern that works:
+
+```yaml
+- name: Checkout 🛎
+  uses: actions/checkout@v7      # explicit step, cannot be factored out
+- uses: ./.github/actions/setup-build-env   # composite: JDK + Maven only
+```
+
+Share the rest (e.g. common Maven flags) via a workflow-level `env:` (like
+`MVN_ARGS`) — keep the value free of internal quotes: it is expanded unquoted
+into the shell command line, and bash/pwsh do not re-parse quotes inside
+expanded variables.
+
+
 Measured on master builds (useful when optimizing CI time):
 
 - Full build ≈ 15 min Maven; `org.moreunit.swtbot.test` ≈ **10:30 (≈ 2/3 of the build)**.

--- a/.claude/skills/moreunit-test-patterns/SKILL.md
+++ b/.claude/skills/moreunit-test-patterns/SKILL.md
@@ -77,8 +77,17 @@ order.verify(container).create();
 
 ## SWTBot test patterns
 
-### Base class
+### SWTBot performance rules (CI cost, measured 2026-09)
 
+SWTBot tests dominate CI time (~10 min of a ~15 min build before optimization). Key facts:
+
+- `TestContextRule` creates **a full Java project per test method** (`beforeEach` → `initWorkspace`, `afterEach` → `clearWorkspace`): every `@Test` method pays project creation + JDT build. Fewer test methods = less overhead.
+- Opening the Eclipse **Preferences** dialog costs ~19 s per opening on Windows CI (it loads every preference page of the IDE). The project-scoped **Properties** dialog is ~1 s.
+- Therefore: **group preference changes into as few dialog sessions as possible** (see `PreferencesTest`: one session per theme of assertions, radios kept separate since each radio change needs save+reopen). Never write one test = one dialog opening.
+- On Eclipse 4.x Windows, preference-page validation messages are often **not discoverable SWT widgets** — validation checks must be *best-effort* (search `label` then `clabel`, catch, never fail the test) with short timeouts (5 s), because a full timeout is pure waste when the message isn't rendered.
+- Full-module SWTBot runs are unstable (workbench can die mid-run); when diagnosing, run single classes (`-Dtest=...`).
+
+### Base class
 All SWTBot tests extend `JavaProjectSWTBotTestHelper` (in `org.moreunit.swtbot.test/test/org/moreunit/`), which provides:
 - `bot` (static `SWTWorkbenchBot`) — the SWTBot API entry point
 - `context` (`@RegisterExtension TestContextRule`) — manages the workspace


### PR DESCRIPTION
Documente les découvertes issues de l'analyse CI (PRs #369, #370) dans les skills agents :

**moreunit-build/SKILL.md** — nouvelles sections :
- `Tycho 5 gotchas` : surefire lié à `integration-test` (et non `test` — `mvn test` n'exécute rien, silencieusement) ; groupIds différents pour `-pl` (`org.moreunit` vs `org.moreunit.plugins`) ; `Require-Bundle` résolu via la target platform/artefacts locaux (et non les deps Maven du reactor) → recette pour lancer un module de test isolé ; syntaxe d'exclusions `-pl '!...'` ; runs de classes isolées pour valider (runs complets SWTBot instables).
- `CI performance knowledge` : timings mesurés (swtbot ≈ 2/3 du build ; ouverture dialogue Preferences ≈ 19 s en CI Windows ; Properties ≈ 1 s ; comment extraire les timings des logs de job).

**moreunit-test-patterns/SKILL.md** — `SWTBot performance rules` :
- `TestContextRule` recrée un projet Java par méthode de test ;
- regrouper les changements de préférences en peu de sessions de dialogue ;
- messages de validation non découvrables sur Eclipse 4.x Windows → checks best-effort + timeouts courts.