### PR TITLE
ci: parallel jobs for unit build and SWTBot tests (-3/4 min)

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -1,0 +1,19 @@
+name: 'Set up build environment'
+description: 'Checkout + JDK 21 (Temurin, Maven cache) + Maven 3.9.9 — shared by all MoreUnit CI jobs'
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout 🛎
+      uses: actions/checkout@v7
+
+    - name: Set up Java ☕️
+      uses: actions/setup-java@v5
+      with:
+        distribution: 'temurin'
+        java-version: '21'
+        cache: 'maven'
+
+    - name: Setup Maven
+      uses: stCarolas/setup-maven@v5
+      with:
+        maven-version: 3.9.9

--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -1,11 +1,8 @@
 name: 'Set up build environment'
-description: 'Checkout + JDK 21 (Temurin, Maven cache) + Maven 3.9.9 — shared by all MoreUnit CI jobs'
+description: 'JDK 21 (Temurin, Maven cache) + Maven 3.9.9 — shared by all MoreUnit CI jobs. Must run AFTER actions/checkout (local action).'
 runs:
   using: 'composite'
   steps:
-    - name: Checkout 🛎
-      uses: actions/checkout@v7
-
     - name: Set up Java ☕️
       uses: actions/setup-java@v5
       with:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,6 +28,9 @@ jobs:
 
     steps:
 
+      - name: Checkout 🛎
+        uses: actions/checkout@v7
+
       - uses: ./.github/actions/setup-build-env
 
       # The SWTBot tests are excluded from this build and run in the
@@ -82,6 +85,9 @@ jobs:
       pull-requests: write
 
     steps:
+
+      - name: Checkout 🛎
+        uses: actions/checkout@v7
 
       - uses: ./.github/actions/setup-build-env
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,6 +9,14 @@ on:
 
 permissions: write-all
 
+# bash instead of the default pwsh on Windows runners: pwsh splits unquoted
+# arguments at the first dot (-Dtarget.platform.classifier=... becomes
+# "-Dtarget" + ".platform.classifier=...", which Maven reads as a lifecycle
+# phase).
+defaults:
+  run:
+    shell: bash
+
 env:
   # Common flags for every mvn invocation (no internal quotes: the value is
   # expanded unquoted into the shell command line)

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,6 +10,8 @@ on:
 permissions: write-all
 
 jobs:
+  # Unit tests + packaging + release. The SWTBot tests run in a parallel job
+  # (swtbot-tests) to shorten the critical path.
   build:
 
     runs-on: windows-latest
@@ -20,24 +22,33 @@ jobs:
       pull-requests: write
 
     steps:
+
       - name: Checkout 🛎
         uses: actions/checkout@v7
-        
+
       - name: Set up Java ☕️
-        uses: actions/setup-java@v6
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '21'
           cache: 'maven'
+
+      - name: Setup Maven
+        uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: 3.9.9
+
+      # The SWTBot tests are excluded from this build and run in the
+      # parallel swtbot-tests job (see the job below).
       - name: Build and verify
-        run: mvn -file org.moreunit.build/pom.xml clean install "-Dtarget.platform.classifier=eclipse-latest" --fail-at-end --batch-mode --strict-checksums --update-snapshots "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+        run: mvn -file org.moreunit.build/pom.xml clean install "-Dtarget.platform.classifier=eclipse-latest" -pl "!org.moreunit.plugins:org.moreunit.swtbot.test" --fail-at-end --batch-mode --strict-checksums --update-snapshots "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
 
       - name: Run PMD and CPD checks
         run: mvn -file org.moreunit.build/pom.xml pmd:check pmd:cpd-check
 
       - name: Publish Surefire Test Results for  🖨
         if: ${{ always() }}
-        uses: ScalableCapital/action-surefire-report@v2
+        uses: ScaCap/action-surefire-report@v1
         with:
           check_name: test results
 
@@ -64,4 +75,50 @@ jobs:
         with:
           files: |
             ./org.moreunit.updatesite/target/org.moreunit.updatesite-*.zip
-            ./org.moreunit.updatesite/target/flat-repository/*        
+            ./org.moreunit.updatesite/target/flat-repository/*
+
+  # SWTBot (UI) tests only, in parallel with the build job. The product
+  # bundles required by the SWTBot module are installed first (tests skipped)
+  # because Tycho resolves Require-Bundle from the installed local artifacts,
+  # not from the Maven reactor.
+  swtbot-tests:
+
+    runs-on: windows-latest
+
+    permissions:
+      checks: write
+      pull-requests: write
+
+    steps:
+
+      - name: Checkout 🛎
+        uses: actions/checkout@v7
+
+      - name: Set up Java ☕️
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+
+      - name: Setup Maven
+        uses: stCarolas/setup-maven@v5
+        with:
+          maven-version: 3.9.9
+
+      # Install only the product bundles required by org.moreunit.swtbot.test
+      # (org.moreunit.core, org.moreunit plugin, org.moreunit.test.dependencies).
+      # -DskipTests also skips test.dependencies' own tests (covered by the build job).
+      - name: Install required product bundles
+        run: mvn -file org.moreunit.build/pom.xml install -DskipTests -pl org.moreunit:org.moreunit.core,org.moreunit.plugins:org.moreunit,org.moreunit.plugins:org.moreunit.test.dependencies "-Dtarget.platform.classifier=eclipse-latest" --batch-mode --strict-checksums --update-snapshots "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+
+      # tycho-surefire is bound to the integration-test phase: use verify (mvn
+      # test would silently run nothing).
+      - name: Run SWTBot tests
+        run: mvn -file org.moreunit.build/pom.xml verify -pl org.moreunit.plugins:org.moreunit.swtbot.test "-Dtarget.platform.classifier=eclipse-latest" --batch-mode --strict-checksums "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+
+      - name: Publish SWTBot Test Results 🖨
+        if: ${{ always() }}
+        uses: ScaCap/action-surefire-report@v1
+        with:
+          check_name: test results (swtbot)

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,6 +9,11 @@ on:
 
 permissions: write-all
 
+env:
+  # Common flags for every mvn invocation (no internal quotes: the value is
+  # expanded unquoted into the shell command line)
+  MVN_ARGS: --batch-mode --strict-checksums --update-snapshots -Dtarget.platform.classifier=eclipse-latest -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+
 jobs:
   # Unit tests + packaging + release. The SWTBot tests run in a parallel job
   # (swtbot-tests) to shorten the critical path.
@@ -23,25 +28,12 @@ jobs:
 
     steps:
 
-      - name: Checkout 🛎
-        uses: actions/checkout@v7
-
-      - name: Set up Java ☕️
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-          cache: 'maven'
-
-      - name: Setup Maven
-        uses: stCarolas/setup-maven@v5
-        with:
-          maven-version: 3.9.9
+      - uses: ./.github/actions/setup-build-env
 
       # The SWTBot tests are excluded from this build and run in the
-      # parallel swtbot-tests job (see the job below).
+      # parallel swtbot-tests job.
       - name: Build and verify
-        run: mvn -file org.moreunit.build/pom.xml clean install "-Dtarget.platform.classifier=eclipse-latest" -pl "!org.moreunit.plugins:org.moreunit.swtbot.test" --fail-at-end --batch-mode --strict-checksums --update-snapshots "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+        run: mvn -file org.moreunit.build/pom.xml clean install ${{ env.MVN_ARGS }} -pl "!org.moreunit.plugins:org.moreunit.swtbot.test" --fail-at-end
 
       - name: Run PMD and CPD checks
         run: mvn -file org.moreunit.build/pom.xml pmd:check pmd:cpd-check
@@ -91,31 +83,18 @@ jobs:
 
     steps:
 
-      - name: Checkout 🛎
-        uses: actions/checkout@v7
-
-      - name: Set up Java ☕️
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-          cache: 'maven'
-
-      - name: Setup Maven
-        uses: stCarolas/setup-maven@v5
-        with:
-          maven-version: 3.9.9
+      - uses: ./.github/actions/setup-build-env
 
       # Install only the product bundles required by org.moreunit.swtbot.test
       # (org.moreunit.core, org.moreunit plugin, org.moreunit.test.dependencies).
       # -DskipTests also skips test.dependencies' own tests (covered by the build job).
       - name: Install required product bundles
-        run: mvn -file org.moreunit.build/pom.xml install -DskipTests -pl org.moreunit:org.moreunit.core,org.moreunit.plugins:org.moreunit,org.moreunit.plugins:org.moreunit.test.dependencies "-Dtarget.platform.classifier=eclipse-latest" --batch-mode --strict-checksums --update-snapshots "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+        run: mvn -file org.moreunit.build/pom.xml install -DskipTests -pl org.moreunit:org.moreunit.core,org.moreunit.plugins:org.moreunit,org.moreunit.plugins:org.moreunit.test.dependencies ${{ env.MVN_ARGS }}
 
       # tycho-surefire is bound to the integration-test phase: use verify (mvn
       # test would silently run nothing).
       - name: Run SWTBot tests
-        run: mvn -file org.moreunit.build/pom.xml verify -pl org.moreunit.plugins:org.moreunit.swtbot.test "-Dtarget.platform.classifier=eclipse-latest" --batch-mode --strict-checksums "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+        run: mvn -file org.moreunit.build/pom.xml verify -pl org.moreunit.plugins:org.moreunit.swtbot.test ${{ env.MVN_ARGS }}
 
       - name: Publish SWTBot Test Results 🖨
         if: ${{ always() }}


### PR DESCRIPTION
## Contexte

Suite à la PR #370 (option 1 : −3:45 sur le module SWTBot), ceci est l'**option 2 convenue** : découper le workflow `MoreUnit Build` en deux jobs parallèles.

## Design

| Job | Contenu | Durée estimée |
|---|---|---|
| `build` | tout sauf le module SWTBot : tests unitaires (core.test, test, mock.test, mock.it, test.dependencies), packaging, PMD, flatten P2, releases | ~6-7 min |
| `swtbot-tests` | 1) `install -DskipTests -pl core,plugin,test.dependencies` (bundles requis par SWTBot — Tycho résout `Require-Bundle` via les artefacts locaux, pas le reactor Maven) 2) `verify -pl swtbot.test` | ~8-9 min |

Chemin critique attendu : **~9 min** (plafonné par l'exécution des tests SWTBot ≈ 6:45 + setup), vs ~12-13 min aujourd'hui.

## Points techniques
- `tycho-surefire` est lié à la phase `integration-test` (Tycho 5) : le step SWTBot utilise `verify` (`test` n'exécuterait rien, silencieusement).
- `-DskipTests` dans le step 1 du job swtbot ne touche que ce job ; les tests de `test.dependencies` restent couverts par le job `build`.
- Les résultats SWTBot sont publiés dans un check distinct : `test results (swtbot)`.
- Les releases (SNAPSHOT/tag) restent dans le job `build` (l'update site n'inclut pas les bundles de test).

## Validation
- Commandes validées localement (offline, warm cache) : `install -DskipTests -pl <3 modules>` ✅, `verify -pl swtbot.test` ✅ (37 tests lancés), reactor sans swtbot ✅.
- CI sur cette PR : à confirmer (2 jobs verts + timings).