### PR TITLE
fix(tests): isole ConcreteSrcFileTest des préférences workspace partagées

### DIFF
--- a/org.moreunit.core.test/test/org/moreunit/core/commands/JumpActionHandlerTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/commands/JumpActionHandlerTest.java
@@ -75,6 +75,9 @@ public class JumpActionHandlerTest extends TmpProjectTestCase
 
         preferences.get(project).activatePreferencesForLanguage(LanguagePreferences.ANY_LANGUAGE, false);
         preferences.get(project).save();
+
+        preferences.writerForAnyLanguage().setTestFileNameTemplate("${srcFile}Test", "");
+        preferences.writerForAnyLanguage().setTestFolderPathTemplate("${srcProject}", "${srcProject}");
     }
 
     @Test

--- a/org.moreunit.core.test/test/org/moreunit/core/resources/ConcreteSrcFileTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/resources/ConcreteSrcFileTest.java
@@ -6,14 +6,33 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.moreunit.core.config.CoreModule.$;
 
 import org.moreunit.core.commands.TmpProjectTestCase;
 import org.moreunit.core.matching.FileNameEvaluation;
 import org.moreunit.core.matching.SourceFolderPath;
+import org.moreunit.core.preferences.Preferences;
 
 public class ConcreteSrcFileTest extends TmpProjectTestCase
 {
+    @BeforeEach
+    public void setUpPreferences()
+    {
+        $().getPreferences().writerForAnyLanguage().setTestFileNameTemplate("${srcFile}Test", "");
+        $().getPreferences().writerForAnyLanguage().setTestFolderPathTemplate("${srcProject}/src", "${srcProject}/test");
+    }
+
+    @AfterEach
+    public void resetPreferences()
+    {
+        $().getPreferences().writerForAnyLanguage().setTestFileNameTemplate(Preferences.DEFAULTS.getTestFileNameTemplate(), Preferences.DEFAULTS.getFileWordSeparator());
+        $().getPreferences().writerForAnyLanguage().setTestFolderPathTemplate(Preferences.DEFAULTS.getSrcFolderPathTemplate(), Preferences.DEFAULTS.getTestFolderPathTemplate());
+    }
+
     private ConcreteSrcFile createSrcFile(String projectRelativePath) throws Exception
     {
         return new ConcreteSrcFile(new EclipseFile(createFile(projectRelativePath)));
@@ -82,13 +101,14 @@ public class ConcreteSrcFileTest extends TmpProjectTestCase
     public void should_find_corresponding_folder_of_test_and_src_files() throws Exception
     {
         ConcreteSrcFile srcFile = createSrcFile("src/Foo.java");
-        ConcreteSrcFile testFile = createSrcFile("src/FooTest.java");
+        ConcreteSrcFile testFile = createSrcFile("test/FooTest.java");
 
-        SourceFolderPath srcFolder = srcFile.findCorrespondingSrcFolder();
-        SourceFolderPath testFolder = testFile.findCorrespondingSrcFolder();
+        SourceFolderPath testFolder = srcFile.findCorrespondingSrcFolder();
+        SourceFolderPath srcFolder = testFile.findCorrespondingSrcFolder();
 
-        assertNotNull(srcFolder);
         assertNotNull(testFolder);
-        assertEquals(srcFolder.toString(), testFolder.toString());
+        assertNotNull(srcFolder);
+        assertEquals(TEST_PROJECT + "/test", testFolder.toString());
+        assertEquals(TEST_PROJECT + "/src", srcFolder.toString());
     }
 }


### PR DESCRIPTION
Corrige l'échec déterministe introduit par le merge du 02/09 (commits 2a9c9cf8..8886b4b5) :

Échec CI (jobs build et coverage, runs 33680076663 / 33680076789) :
ConcreteSrcFileTest.should_find_corresponding_folder_of_test_and_src_files:92 expected: <test-project/test> but was: <test-project/src>

Cause : le nouveau test plaçait src et test dans le même dossier src/ et assertait l'égalité des dossiers correspondants. Avec un découpage src/test configuré, findCorrespondingSrcFolder retourne test-project/test pour un fichier src et test-project/src pour un fichier test, donc l'assertion est fausse par construction. En pratique le test dépendait en plus de l'ordre d'exécution : JumpActionHandlerTest laisse les templates anyLanguage à src/test dans le store partagé sans les réinitialiser.

Changements (tests uniquement, sans commentaire dans le code) :
- ConcreteSrcFileTest : configure ses propres préférences en setup/teardown et teste le mapping croisé réel (src/Foo.java -> test-project/test, test/FooTest.java -> test-project/src).
- JumpActionHandlerTest : réinitialise les templates workspace dans cleanPreferences pour ne plus polluer les autres classes.

Note : l'échec SWTBot MoveMethodTest sur master (timeout 20s) est flaky — le même SHA a passé les 36 tests SWTBot sur la PR test/raise-production-coverage (run 33640521807). Non modifié par cette PR.

Validation locale (Tycho, offline) :
- -Dtest=ConcreteSrcFileTest : 6/6 OK
- module org.moreunit.core.test complet : BUILD SUCCESS, ConcreteSrcFileTest 6/6, JumpActionHandlerTest 19/19