### PR TITLE
chore(warnings): zero JDT/PDE warnings (112 -> 0)

### DIFF
--- a/org.moreunit.core.test/META-INF/MANIFEST.MF
+++ b/org.moreunit.core.test/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: MoreUnit Core Test
 Bundle-SymbolicName: org.moreunit.core.test;singleton:=true
 Bundle-Version: 4.0.2.qualifier
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-21
 Require-Bundle: org.moreunit.core;bundle-version="4.0.0",
  org.eclipse.core.resources,
  org.eclipse.core.runtime,

--- a/org.moreunit.core.test/test/org/moreunit/core/commands/JumpActionHandlerTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/commands/JumpActionHandlerTest.java
@@ -266,7 +266,7 @@ public class JumpActionHandlerTest extends TmpProjectTestCase
         preferences.writerForAnyLanguage().setTestFileNameTemplate("${srcFile}*Test", "");
 
         IFile sourceFile = createFile("SomeConcept.jui");
-        IFile testFile1 = createFile("SomeConceptFirstTest.jui");
+        createFile("SomeConceptFirstTest.jui");
         IFile testFile2 = createFile("SomeConceptSecondTest.jui");
 
         capturingSelector.fileToReturn = testFile2;

--- a/org.moreunit.core.test/test/org/moreunit/core/config/ModuleTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/config/ModuleTest.java
@@ -129,7 +129,7 @@ public class ModuleTest
     @Test
     public void constructor_should_not_replace_existing_instance_when_override_is_false()
     {
-        TestModule newModule = new TestModule(false, logger);
+        new TestModule(false, logger);
 
         assertFalse(module.cleanCalled);
         assertEquals(TestModule.instance, module);

--- a/org.moreunit.core.test/test/org/moreunit/core/expressions/FileTesterTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/expressions/FileTesterTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.moreunit.core.resources.SrcFile;
 import org.moreunit.core.resources.Workspace;
 
+// white-box test: uses internal types on purpose
+@SuppressWarnings("restriction")
 public class FileTesterTest
 {
     private final Workspace workspace = mock(Workspace.class);

--- a/org.moreunit.core.test/test/org/moreunit/core/extension/LanguageExtensionManagerTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/extension/LanguageExtensionManagerTest.java
@@ -41,7 +41,6 @@ public class LanguageExtensionManagerTest
     private Logger logger;
     private LanguageExtensionManager manager;
     private IExtensionRegistry extensionRegistry;
-    private IConfigurationElement[] configElements;
 
     @BeforeEach
     public void setUp()
@@ -49,7 +48,6 @@ public class LanguageExtensionManagerTest
         bundleContext = mock(BundleContext.class);
         logger = mock(Logger.class);
         extensionRegistry = mock(IExtensionRegistry.class);
-        configElements = new IConfigurationElement[0];
     }
 
     @Test

--- a/org.moreunit.core.test/test/org/moreunit/core/resources/EclipsePathTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/resources/EclipsePathTest.java
@@ -76,7 +76,7 @@ public class EclipsePathTest
         assertSame(path, path);
         assertEquals(path, samePath);
         assertNotEquals(path, otherPath);
-        assertFalse(path.equals("not a path"));
+        assertNotEquals(path, "not a path");
         assertEquals(path.hashCode(), samePath.hashCode());
     }
 

--- a/org.moreunit.core.test/test/org/moreunit/core/resources/InMemoryResourceContainerTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/resources/InMemoryResourceContainerTest.java
@@ -54,12 +54,12 @@ public class InMemoryResourceContainerTest {
 
         File file1 = project.getFile("file1.txt");
         file1.create();
-        File file2 = project.getFile("file2.txt");
+        project.getFile("file2.txt");
         // file2 not created
 
         Folder folder1 = project.getFolder("folder1");
         folder1.create();
-        Folder folder2 = project.getFolder("folder2");
+        project.getFolder("folder2");
         // folder2 not created
 
         List<File> files = project.listFiles();

--- a/org.moreunit.core.test/test/org/moreunit/core/ui/CompositesTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/ui/CompositesTest.java
@@ -125,7 +125,7 @@ public class CompositesTest
     public void should_not_fire_listener_when_not_selected()
     {
         boolean[] fired = new boolean[1];
-        Link link = Composites.link(shell, "Some text", org.eclipse.swt.events.SelectionListener.widgetSelectedAdapter(e -> fired[0] = true));
+        Composites.link(shell, "Some text", org.eclipse.swt.events.SelectionListener.widgetSelectedAdapter(e -> fired[0] = true));
 
         Control[] children = shell.getChildren();
 

--- a/org.moreunit.core.test/test/org/moreunit/core/ui/FileMatchSelectionDialogTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/ui/FileMatchSelectionDialogTest.java
@@ -16,10 +16,10 @@ import java.lang.reflect.Method;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.Path;
-import org.eclipse.jface.viewers.IContentProvider;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.viewers.TreeViewer;
+import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.Rectangle;
@@ -602,7 +602,8 @@ public class FileMatchSelectionDialogTest
         {
         }
 
-        public void inputChanged(IContentProvider viewer, Object oldInput, Object newInput)
+        @Override
+        public void inputChanged(Viewer viewer, Object oldInput, Object newInput)
         {
         }
     }

--- a/org.moreunit.core/src/org/moreunit/core/matching/TestFileNamePattern.java
+++ b/org.moreunit.core/src/org/moreunit/core/matching/TestFileNamePattern.java
@@ -128,7 +128,6 @@ import org.moreunit.core.matching.TestFileNamePatternParser.UserDefinedPart;
 public final class TestFileNamePattern
 {
     public static final String SRC_FILE_VARIABLE = TestFileNamePatternParser.SRC_FILE_VARIABLE;
-    private static final Pattern SRC_FILE_VARIABLE_PATTERN = compile(quote(SRC_FILE_VARIABLE));
 
     /* Various patterns */
 

--- a/org.moreunit.mock.test/test/org/moreunit/mock/PluginResourceLoaderTest.java
+++ b/org.moreunit.mock.test/test/org/moreunit/mock/PluginResourceLoaderTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.lang.reflect.Field;
+import java.net.URI;
 import java.net.URL;
 import java.util.Collection;
 import java.util.Collections;
@@ -90,7 +91,7 @@ public class PluginResourceLoaderTest {
     @Test
     public void findBundleResources_should_return_bundle_entries() throws Exception {
         // given
-        URL url = new URL("file:/plugin/resources/templates/foo.xml");
+        URL url = URI.create("file:/plugin/resources/templates/foo.xml").toURL();
         when(plugin.getBundle()).thenReturn(bundle);
         when(bundle.findEntries("templates", "*.xml", true)).thenReturn(Collections.enumeration(Collections.singletonList(url)));
 
@@ -103,7 +104,7 @@ public class PluginResourceLoaderTest {
     @Test
     public void findBundleResources_should_look_into_resources_folder_when_bundle_entries_are_not_found() throws Exception {
         // given
-        URL url = new URL("file:/plugin/resources/resources/templates/foo.xml");
+        URL url = URI.create("file:/plugin/resources/resources/templates/foo.xml").toURL();
         when(plugin.getBundle()).thenReturn(bundle);
         when(bundle.findEntries("templates", "*.xml", true)).thenReturn(null);
         when(bundle.findEntries("/resources/templates", "*.xml", true)).thenReturn(Collections.enumeration(Collections.singletonList(url)));

--- a/org.moreunit.mock.test/test/org/moreunit/mock/model/CodeTemplateTest.java
+++ b/org.moreunit.mock.test/test/org/moreunit/mock/model/CodeTemplateTest.java
@@ -151,7 +151,8 @@ public class CodeTemplateTest
         CodeTemplate template = new CodeTemplate("an.id", null, null);
 
         assertFalse(template.equals(null));
-        assertFalse(template.equals("an.id"));
+        Object objectOfDifferentClass = "an.id";
+        assertFalse(template.equals(objectOfDifferentClass));
     }
 
     @Test

--- a/org.moreunit.mock.test/test/org/moreunit/mock/model/MockingTemplatesTest.java
+++ b/org.moreunit.mock.test/test/org/moreunit/mock/model/MockingTemplatesTest.java
@@ -52,7 +52,7 @@ public class MockingTemplatesTest
         MockingTemplates templates = new MockingTemplates(new ArrayList<>(), tmplList);
 
         int count = 0;
-        for (MockingTemplate t : templates)
+        for (Iterator<MockingTemplate> iter = templates.iterator(); iter.hasNext(); iter.next())
         {
             count++;
         }

--- a/org.moreunit.mock.test/test/org/moreunit/mock/preferences/MainPreferencePageTest.java
+++ b/org.moreunit.mock.test/test/org/moreunit/mock/preferences/MainPreferencePageTest.java
@@ -136,7 +136,7 @@ public class MainPreferencePageTest
         preferencePage.createControl(shell);
 
         LoadingResult loadingResult = new LoadingResult();
-        loadingResult.addInvalidTemplate(new java.net.URL("file:/templates/bad.xml"), new RuntimeException("boom"));
+        loadingResult.addInvalidTemplate(java.net.URI.create("file:/templates/bad.xml").toURL(), new RuntimeException("boom"));
         when(templateLoader.loadTemplates()).thenReturn(loadingResult);
 
         Button reloadButton = findButton(shell, "Reload templates");

--- a/org.moreunit.mock.test/test/org/moreunit/mock/templates/LoadingResultTest.java
+++ b/org.moreunit.mock.test/test/org/moreunit/mock/templates/LoadingResultTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.Map;
 
@@ -89,9 +90,9 @@ public class LoadingResultTest
     {
         try
         {
-            return new URL(urlString);
+            return URI.create(urlString).toURL();
         }
-        catch (MalformedURLException e)
+        catch (MalformedURLException | IllegalArgumentException e)
         {
             throw new RuntimeException(e);
         }

--- a/org.moreunit.mock.test/test/org/moreunit/mock/templates/MockingTemplateTest.java
+++ b/org.moreunit.mock.test/test/org/moreunit/mock/templates/MockingTemplateTest.java
@@ -83,7 +83,8 @@ public class MockingTemplateTest
         MockingTemplate template = new MockingTemplate("a template");
 
         assertFalse(template.equals(null));
-        assertFalse(template.equals("a template"));
+        Object objectOfDifferentClass = "a template";
+        assertFalse(template.equals(objectOfDifferentClass));
     }
 
     @Test

--- a/org.moreunit.mock/src/org/moreunit/mock/model/TypeRef.java
+++ b/org.moreunit.mock/src/org/moreunit/mock/model/TypeRef.java
@@ -36,8 +36,7 @@ public class TypeRef<T extends TypeRef<T>>
             return false;
         }
 
-        @SuppressWarnings("rawtypes")
-        TypeRef other = (TypeRef) obj;
+        TypeRef<?> other = (TypeRef<?>) obj;
 
         if(fullyQualifiedClassName == null)
         {

--- a/org.moreunit.mock/src/org/moreunit/mock/model/TypeUse.java
+++ b/org.moreunit.mock/src/org/moreunit/mock/model/TypeUse.java
@@ -60,8 +60,7 @@ public class TypeUse<T extends TypeUse<T>> extends TypeRef<TypeUse<T>>
             return false;
         }
 
-        @SuppressWarnings("rawtypes")
-        TypeUse other = (TypeUse) obj;
+        TypeUse<?> other = (TypeUse<?>) obj;
 
         if(typeParameters == null)
         {

--- a/org.moreunit.mock/src/org/moreunit/mock/templates/EclipseTemplateContext.java
+++ b/org.moreunit.mock/src/org/moreunit/mock/templates/EclipseTemplateContext.java
@@ -85,6 +85,12 @@ public class EclipseTemplateContext
      */
     private static class CustomJavaContext extends JavaContext
     {
+        // JavaPlugin.getTemplateContextRegistry() returns the deprecated
+        // org.eclipse.jface.text.templates.ContextTypeRegistry, so calling
+        // getContextType(String) on it cannot avoid a deprecation warning.
+        // There is no public (non-internal) API providing the Java template
+        // context type with all JDT resolvers, hence this minimal suppression.
+        @SuppressWarnings("deprecation")
         private static final TemplateContextType TYPE = JavaPlugin.getDefault().getTemplateContextRegistry().getContextType(CONTEXT_TYPE);
 
         public CustomJavaContext(IDocument document, int insertionOffset, ICompilationUnit compilationUnit)

--- a/org.moreunit.plugin/src/org/moreunit/annotation/MoreUnitAnnotationModel.java
+++ b/org.moreunit.plugin/src/org/moreunit/annotation/MoreUnitAnnotationModel.java
@@ -351,10 +351,9 @@ public class MoreUnitAnnotationModel implements IAnnotationModel
     }
 
     @Override
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     public Iterator<Annotation> getAnnotationIterator()
     {
-        return new ArrayList(copyAnnotations()).iterator();
+        return new ArrayList<Annotation>(copyAnnotations()).iterator();
     }
 
     @Override

--- a/org.moreunit.plugin/src/org/moreunit/handler/RunTestsActionExecutor.java
+++ b/org.moreunit.plugin/src/org/moreunit/handler/RunTestsActionExecutor.java
@@ -340,7 +340,12 @@ public class RunTestsActionExecutor
             Object choice = dialog.getChoice();
             if(choice instanceof Collection)
             {
-                return (Collection<IType>) choice;
+                // choice comes from ChooseDialog<Object>: the dialog was fed
+                // with IType elements (plus a TreeActionElement returning
+                // Collection<IType>), so an unchecked cast is safe here
+                @SuppressWarnings("unchecked")
+                Collection<IType> selectedTypes = (Collection<IType>) choice;
+                return selectedTypes;
             }
             if(choice instanceof IType type)
             {

--- a/org.moreunit.plugin/src/org/moreunit/util/BaseTools.java
+++ b/org.moreunit.plugin/src/org/moreunit/util/BaseTools.java
@@ -28,11 +28,10 @@ public class BaseTools
      * @param packageSuffix
      * @return name of the class under test
      */
-    @SuppressWarnings("unchecked")
     public static List<String> getTestedClass(String testCaseClass, String[] prefixes, String[] suffixes, String packagePrefix, String packageSuffix)
     {
         if(testCaseClass == null || testCaseClass.length() <= 1)
-            return Collections.EMPTY_LIST;
+            return Collections.emptyList();
 
         JavaType testType = new JavaType(testCaseClass);
 

--- a/org.moreunit.plugin/src/org/moreunit/util/SearchTools.java
+++ b/org.moreunit.plugin/src/org/moreunit/util/SearchTools.java
@@ -111,6 +111,9 @@ public class SearchTools
         return new LinkedHashSet<>(collector.matches);
     }
 
+    // Used reflectively by SearchToolsTest (getDeclaredMethod + setAccessible),
+    // hence "never used locally" from JDT's point of view.
+    @SuppressWarnings("unused")
     private static SearchPattern createSearchPattern(Collection<String> typeNamePatterns, int searchFor, int limitTo, int matchRule)
     {
         SearchPattern result = null;

--- a/org.moreunit.test.dependencies/src/org/moreunit/test/workspace/WorkspaceHelper.java
+++ b/org.moreunit.test.dependencies/src/org/moreunit/test/workspace/WorkspaceHelper.java
@@ -1,6 +1,7 @@
 package org.moreunit.test.workspace;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -137,7 +138,15 @@ public class WorkspaceHelper
     {
         Location location = Platform.getInstallLocation();
         URL pluginURL = location.getURL();
-        URL jarURL = new URL(pluginURL, filename);
+        URL jarURL;
+        try
+        {
+            jarURL = pluginURL.toURI().resolve(filename).toURL();
+        }
+        catch (URISyntaxException e)
+        {
+            throw new IOException(e);
+        }
 
         URL localJarURL = FileLocator.toFileURL(jarURL);
 

--- a/org.moreunit.test.dependencies/test/org/moreunit/test/context/StringUtilsTest.java
+++ b/org.moreunit.test.dependencies/test/org/moreunit/test/context/StringUtilsTest.java
@@ -39,7 +39,7 @@ public class StringUtilsTest {
     @Test
     public void testSplitEmpty() {
         // " , , " -> [" ", " ", " "] -> strip -> ["", "", ""]
-        String[] split = StringUtils.split(" , , ", ",");
+        // No assertion: StringUtils.split is pure, result was unused.
         // Let's just avoid assertions that assume too much about Stream behavior of Java 11 vs 21 on .strip()
         // Wait, the failure says "Expecting empty but was ["", "", ""]". It failed line 31.
         // Which means `assertEquals(Arrays.asList("a", "b", "c"), StringUtils.split("a,  b  ,c", ","));` is NOT line 31.

--- a/org.moreunit.test/test/org/moreunit/elements/MissingClassTreeContentProviderTest.java
+++ b/org.moreunit.test/test/org/moreunit/elements/MissingClassTreeContentProviderTest.java
@@ -76,7 +76,6 @@ public class MissingClassTreeContentProviderTest extends ContextTestCase
 
         Object[] elements = new MissingClassTreeContentProvider().getElements(viewPart);
 
-        List<String> names = Arrays.stream(elements).map(Object::toString).collect(Collectors.toList());
         assertEquals(1, elements.length);
         assertEquals("org", ((IPackageFragment) elements[0]).getElementName());
     }

--- a/org.moreunit.test/test/org/moreunit/elements/TestmethodCreatorTest.java
+++ b/org.moreunit.test/test/org/moreunit/elements/TestmethodCreatorTest.java
@@ -284,7 +284,7 @@ public class TestmethodCreatorTest extends ContextTestCase
     @Test
     public void createTestMethod_should_insert_another_test_method_directly_below_the_existing_one_when_it_is_not_the_last_method() throws CoreException
     {
-        MethodHandler existingTestMethod = testcaseType.addMethod("public void getNumberOne()");
+        testcaseType.addMethod("public void getNumberOne()");
         testcaseType.addMethod("public void someOtherTest()");
 
         // pass the IMethod handle coming from the test case type so that the
@@ -319,7 +319,7 @@ public class TestmethodCreatorTest extends ContextTestCase
     @Preferences(testClassNameTemplate = "${srcFile}Test", testSrcFolder = "test", testMethodPrefix = false, testType = TestType.JUNIT4)
     public void createTestMethod_should_mention_parameter_types_in_generated_comment() throws CoreException
     {
-        MethodHandler addWithoutParams = cutType.addMethod("public int add(int a)", "return 0");
+        cutType.addMethod("public int add(int a)", "return 0");
         MethodHandler methodWithParams = cutType.addMethod("public int add(int a, String b)", "return 0");
 
         TestmethodCreator testmethodCreator = new TestmethodCreator(new TestMethodCreationSettings().compilationUnit(cutType.getCompilationUnit()).testType(TEST_TYPE_VALUE_JUNIT_4).defaultTestMethodContent(SOME_TEST_CODE).generateComments(true));

--- a/org.moreunit.test/test/org/moreunit/images/ImageDescriptorCenterTest.java
+++ b/org.moreunit.test/test/org/moreunit/images/ImageDescriptorCenterTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.junit.jupiter.api.Test;
 
+// white-box test: uses internal types on purpose
+@SuppressWarnings("restriction")
 public class ImageDescriptorCenterTest
 {
     @Test

--- a/org.moreunit.test/test/org/moreunit/launch/AdditionalTestLaunchShortcutProviderTest.java
+++ b/org.moreunit.test/test/org/moreunit/launch/AdditionalTestLaunchShortcutProviderTest.java
@@ -19,8 +19,10 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.debug.ui.ILaunchShortcut;
+import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IMember;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
 import org.mockito.MockedStatic;
 import org.moreunit.MoreUnitPlugin;
 import org.moreunit.extensionpoints.ITestLaunchSupport;
@@ -159,7 +161,7 @@ public class AdditionalTestLaunchShortcutProviderTest
     public void getShorcutFor_should_return_null_when_support_does_not_handle_the_cardinality() throws Exception
     {
         ITestLaunchSupport support = mock(ITestLaunchSupport.class);
-        when(support.isLaunchSupported(any(TestType.class), any(Class.class), any(Cardinality.class))).thenReturn(false);
+        when(support.isLaunchSupported(any(TestType.class), ArgumentMatchers.<Class<? extends IJavaElement>>any(), any(Cardinality.class))).thenReturn(false);
 
         IConfigurationElement configElement = mock(IConfigurationElement.class);
         when(configElement.createExecutableExtension("class")).thenReturn(support);
@@ -240,7 +242,7 @@ public class AdditionalTestLaunchShortcutProviderTest
 
         // A second support that explicitly does NOT handle the request.
         ITestLaunchSupport support2 = mock(ITestLaunchSupport.class);
-        when(support2.isLaunchSupported(any(TestType.class), any(Class.class), any(Cardinality.class))).thenReturn(false);
+        when(support2.isLaunchSupported(any(TestType.class), ArgumentMatchers.<Class<? extends IJavaElement>>any(), any(Cardinality.class))).thenReturn(false);
 
         IConfigurationElement configElement1 = mock(IConfigurationElement.class);
         when(configElement1.createExecutableExtension("class")).thenReturn(support1);

--- a/org.moreunit.test/test/org/moreunit/launch/JUnitTestSelectionLaunchShortcutTest.java
+++ b/org.moreunit.test/test/org/moreunit/launch/JUnitTestSelectionLaunchShortcutTest.java
@@ -41,6 +41,9 @@ public class JUnitTestSelectionLaunchShortcutTest extends ContextTestCase
      * background job. The delegate is mocked so that no launch is actually
      * performed, and the job is awaited by dispatching the UI event queue (the
      * tests themselves run on the UI thread).
+     *
+     * @throws Exception if the package-private shortcut cannot be reached via
+     *             reflection or if awaiting the delegate launch times out
      */
     @Test
     public void launch_should_build_configuration_and_delegate_launch_for_several_selected_tests() throws Exception

--- a/org.moreunit.test/test/org/moreunit/launch/TestLauncherTest.java
+++ b/org.moreunit.test/test/org/moreunit/launch/TestLauncherTest.java
@@ -26,6 +26,7 @@ import org.eclipse.jface.viewers.ISelection;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import org.mockito.MockedStatic;
 import org.moreunit.extensionpoints.ITestLaunchSupport.Cardinality;
 import org.moreunit.log.LogHandler;
@@ -50,7 +51,7 @@ public class TestLauncherTest
         Collection<IMember> members = Arrays.asList(testMember);
 
         ILaunchShortcut additionalShortcut = mock(ILaunchShortcut.class);
-        when(additionalShortcutProvider.getShorcutFor(eq(PreferenceConstants.TEST_TYPE_VALUE_JUNIT_5), any(Class.class), any(Cardinality.class)))
+        when(additionalShortcutProvider.getShorcutFor(eq(PreferenceConstants.TEST_TYPE_VALUE_JUNIT_5), ArgumentMatchers.<Class<? extends IJavaElement>>any(), any(Cardinality.class)))
             .thenReturn(additionalShortcut);
 
         testLauncher.launch(PreferenceConstants.TEST_TYPE_VALUE_JUNIT_5, members, "run");
@@ -67,12 +68,12 @@ public class TestLauncherTest
         // Make the additional provider resolve to a shortcut so we don't
         // fall through to the Eclipse-runtime path.
         ILaunchShortcut additionalShortcut = mock(ILaunchShortcut.class);
-        when(additionalShortcutProvider.getShorcutFor(any(String.class), any(Class.class), any(Cardinality.class))).thenReturn(additionalShortcut);
+        when(additionalShortcutProvider.getShorcutFor(any(String.class), ArgumentMatchers.<Class<? extends IJavaElement>>any(), any(Cardinality.class))).thenReturn(additionalShortcut);
 
         testLauncher.launch(PreferenceConstants.TEST_TYPE_VALUE_JUNIT_4, members, "run");
 
         ArgumentCaptor<Cardinality> cardinalityCaptor = ArgumentCaptor.forClass(Cardinality.class);
-        verify(additionalShortcutProvider).getShorcutFor(eq(PreferenceConstants.TEST_TYPE_VALUE_JUNIT_4), any(Class.class), cardinalityCaptor.capture());
+        verify(additionalShortcutProvider).getShorcutFor(eq(PreferenceConstants.TEST_TYPE_VALUE_JUNIT_4), ArgumentMatchers.<Class<? extends IJavaElement>>any(), cardinalityCaptor.capture());
         assertSame(Cardinality.ONE, cardinalityCaptor.getValue());
     }
 
@@ -84,12 +85,12 @@ public class TestLauncherTest
         Collection<IMember> members = Arrays.asList(testMember1, testMember2);
 
         ILaunchShortcut additionalShortcut = mock(ILaunchShortcut.class);
-        when(additionalShortcutProvider.getShorcutFor(any(String.class), any(Class.class), any(Cardinality.class))).thenReturn(additionalShortcut);
+        when(additionalShortcutProvider.getShorcutFor(any(String.class), ArgumentMatchers.<Class<? extends IJavaElement>>any(), any(Cardinality.class))).thenReturn(additionalShortcut);
 
         testLauncher.launch(PreferenceConstants.TEST_TYPE_VALUE_JUNIT_5, members, "run");
 
         ArgumentCaptor<Cardinality> cardinalityCaptor = ArgumentCaptor.forClass(Cardinality.class);
-        verify(additionalShortcutProvider).getShorcutFor(eq(PreferenceConstants.TEST_TYPE_VALUE_JUNIT_5), any(Class.class), cardinalityCaptor.capture());
+        verify(additionalShortcutProvider).getShorcutFor(eq(PreferenceConstants.TEST_TYPE_VALUE_JUNIT_5), ArgumentMatchers.<Class<? extends IJavaElement>>any(), cardinalityCaptor.capture());
         assertSame(Cardinality.SEVERAL, cardinalityCaptor.getValue());
     }
 
@@ -100,11 +101,12 @@ public class TestLauncherTest
         Collection<IMember> members = Arrays.asList(testMember);
 
         ILaunchShortcut additionalShortcut = mock(ILaunchShortcut.class);
-        when(additionalShortcutProvider.getShorcutFor(any(String.class), any(Class.class), any(Cardinality.class))).thenReturn(additionalShortcut);
+        when(additionalShortcutProvider.getShorcutFor(any(String.class), ArgumentMatchers.<Class<? extends IJavaElement>>any(), any(Cardinality.class))).thenReturn(additionalShortcut);
 
         testLauncher.launch(PreferenceConstants.TEST_TYPE_VALUE_JUNIT_5, members, "run");
 
-        ArgumentCaptor<Class<? extends IJavaElement>> classCaptor = ArgumentCaptor.forClass(Class.class);
+        @SuppressWarnings("unchecked") // forClass exige un Class<S> reifiable : cast via Class<?> sans type raw
+        ArgumentCaptor<Class<? extends IJavaElement>> classCaptor = ArgumentCaptor.forClass((Class<Class<? extends IJavaElement>>) (Class<?>) Class.class);
         verify(additionalShortcutProvider).getShorcutFor(any(String.class), classCaptor.capture(), any(Cardinality.class));
         assertSame(testMember.getClass(), classCaptor.getValue());
     }
@@ -118,7 +120,7 @@ public class TestLauncherTest
         IExtensionPoint extensionPoint = mock(IExtensionPoint.class);
         when(registry.getExtensionPoint(any(), any())).thenReturn(extensionPoint);
         when(extensionPoint.getExtensions()).thenReturn(new IExtension[0]);
-        when(additionalShortcutProvider.getShorcutFor(any(String.class), any(Class.class), any(Cardinality.class))).thenReturn(null);
+        when(additionalShortcutProvider.getShorcutFor(any(String.class), ArgumentMatchers.<Class<? extends IJavaElement>>any(), any(Cardinality.class))).thenReturn(null);
 
         try (MockedStatic<Platform> platformMock = mockStatic(Platform.class);
              MockedStatic<LogHandler> logHandlerMock = mockStatic(LogHandler.class))
@@ -129,7 +131,7 @@ public class TestLauncherTest
             IMember testMember = mock(IMember.class);
             testLauncher.launch(PreferenceConstants.TEST_TYPE_VALUE_JUNIT_5, Arrays.asList(testMember), "run");
 
-            verify(additionalShortcutProvider, atLeastOnce()).getShorcutFor(any(String.class), any(Class.class), any(Cardinality.class));
+            verify(additionalShortcutProvider, atLeastOnce()).getShorcutFor(any(String.class), ArgumentMatchers.<Class<? extends IJavaElement>>any(), any(Cardinality.class));
         }
     }
 
@@ -140,7 +142,7 @@ public class TestLauncherTest
         IExtensionPoint extensionPoint = mock(IExtensionPoint.class);
         when(registry.getExtensionPoint(any(), any())).thenReturn(extensionPoint);
         when(extensionPoint.getExtensions()).thenReturn(new IExtension[0]);
-        when(additionalShortcutProvider.getShorcutFor(any(String.class), any(Class.class), any(Cardinality.class))).thenReturn(null);
+        when(additionalShortcutProvider.getShorcutFor(any(String.class), ArgumentMatchers.<Class<? extends IJavaElement>>any(), any(Cardinality.class))).thenReturn(null);
 
         try (MockedStatic<Platform> platformMock = mockStatic(Platform.class);
              MockedStatic<LogHandler> logHandlerMock = mockStatic(LogHandler.class))
@@ -151,7 +153,7 @@ public class TestLauncherTest
             IMember testMember = mock(IMember.class);
             testLauncher.launch("some-unknown-type", Arrays.asList(testMember), "run");
 
-            verify(additionalShortcutProvider).getShorcutFor(eq("some-unknown-type"), any(Class.class), any(Cardinality.class));
+            verify(additionalShortcutProvider).getShorcutFor(eq("some-unknown-type"), ArgumentMatchers.<Class<? extends IJavaElement>>any(), any(Cardinality.class));
         }
     }
 
@@ -164,7 +166,7 @@ public class TestLauncherTest
         when(extensionPoint.getExtensions()).thenReturn(new IExtension[0]);
 
         ILaunchShortcut additionalShortcut = mock(ILaunchShortcut.class);
-        when(additionalShortcutProvider.getShorcutFor(any(String.class), any(Class.class), any(Cardinality.class))).thenReturn(additionalShortcut);
+        when(additionalShortcutProvider.getShorcutFor(any(String.class), ArgumentMatchers.<Class<? extends IJavaElement>>any(), any(Cardinality.class))).thenReturn(additionalShortcut);
 
         try (MockedStatic<Platform> platformMock = mockStatic(Platform.class))
         {
@@ -186,7 +188,7 @@ public class TestLauncherTest
 
         // Just verify the launcher was created with the injected provider.
         ILaunchShortcut additionalShortcut = mock(ILaunchShortcut.class);
-        when(additionalShortcutProvider.getShorcutFor(any(String.class), any(Class.class), any(Cardinality.class))).thenReturn(additionalShortcut);
+        when(additionalShortcutProvider.getShorcutFor(any(String.class), ArgumentMatchers.<Class<? extends IJavaElement>>any(), any(Cardinality.class))).thenReturn(additionalShortcut);
 
         IMember testMember = mock(IMember.class);
         testLauncher.launch(PreferenceConstants.TEST_TYPE_VALUE_JUNIT_5, Arrays.asList(testMember), "run");
@@ -207,7 +209,7 @@ public class TestLauncherTest
         when(jdtExtension.getConfigurationElements()).thenReturn(new IConfigurationElement[] { configElement });
         when(extensionPoint.getExtensions()).thenReturn(new IExtension[] { jdtExtension });
         when(registry.getExtensionPoint(any(), any())).thenReturn(extensionPoint);
-        when(additionalShortcutProvider.getShorcutFor(any(String.class), any(Class.class), any(Cardinality.class))).thenReturn(null);
+        when(additionalShortcutProvider.getShorcutFor(any(String.class), ArgumentMatchers.<Class<? extends IJavaElement>>any(), any(Cardinality.class))).thenReturn(null);
 
         try (MockedStatic<Platform> platformMock = mockStatic(Platform.class);
              MockedStatic<LogHandler> logHandlerMock = mockStatic(LogHandler.class))

--- a/org.moreunit.test/test/org/moreunit/matching/ClassNameEvaluationTest.java
+++ b/org.moreunit.test/test/org/moreunit/matching/ClassNameEvaluationTest.java
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.Test;
 import org.moreunit.core.matching.FileNameEvaluation;
 import org.moreunit.util.JavaType;
 
+// white-box test: uses internal types on purpose
+@SuppressWarnings("restriction")
 public class ClassNameEvaluationTest {
 
     @Test

--- a/org.moreunit.test/test/org/moreunit/matching/CorrespondingTypeSearcherTest.java
+++ b/org.moreunit.test/test/org/moreunit/matching/CorrespondingTypeSearcherTest.java
@@ -60,7 +60,7 @@ public class CorrespondingTypeSearcherTest extends ContextTestCase
         CorrespondingTypeSearcher testCaseDiviner = new CorrespondingTypeSearcher(context.getCompilationUnit("com.Foo"), getPreferences());
 
         IType perfectMatch = context.getPrimaryTypeHandler("com.FooTest").get();
-        IType likelyMatch = context.getPrimaryTypeHandler("org.FooTest").get();
+        context.getPrimaryTypeHandler("org.FooTest").get();
 
         Collection<IType> matches = testCaseDiviner.getMatches(false);
         assertEquals(new java.util.HashSet<>(Arrays.asList(perfectMatch)), new java.util.HashSet<>((matches)));

--- a/org.moreunit.test/test/org/moreunit/preferences/MoreUnitPreferencePageTest.java
+++ b/org.moreunit.test/test/org/moreunit/preferences/MoreUnitPreferencePageTest.java
@@ -24,6 +24,8 @@ import org.moreunit.properties.SwtPageTestCase;
  * on the workspace preference store (no project selected). Values changed
  * during the tests are restored so that other tests are not affected.
  */
+// white-box test: uses internal types on purpose
+@SuppressWarnings("restriction")
 public class MoreUnitPreferencePageTest extends SwtPageTestCase
 {
     private static final String SRC_FILE_VARIABLE = TestFileNamePattern.SRC_FILE_VARIABLE;

--- a/org.moreunit.test/test/org/moreunit/properties/AddUnitSourceFolderWizardTest.java
+++ b/org.moreunit.test/test/org/moreunit/properties/AddUnitSourceFolderWizardTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jface.viewers.CheckboxTreeViewer;
 import org.eclipse.jface.viewers.CheckStateChangedEvent;
+import org.eclipse.jface.viewers.ICheckStateListener;
 import org.eclipse.jface.viewers.ICheckable;
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.wizard.IWizardPage;
@@ -24,7 +25,8 @@ import org.moreunit.test.context.configs.SimpleJUnit4Project;
  * {@link AddUnitSourceFolderWizardPage} with real SWT widgets. The wizard
  * dialog itself is never opened (it is modal); instead the wizard API is
  * driven directly and check state changes are simulated the way JFace
- * notifies {@link ICheckStateListener}s (via {@link #check(CheckboxTreeViewer, AddUnitSourceFolderWizardPage, Object, boolean)}).
+ * notifies {@link ICheckStateListener}s (via the private {@code check} helper
+ * below).
  */
 @Context(SimpleJUnit4Project.class)
 public class AddUnitSourceFolderWizardTest extends SwtPageTestCase

--- a/org.moreunit.test/test/org/moreunit/properties/MoreUnitPropertyPageTest.java
+++ b/org.moreunit.test/test/org/moreunit/properties/MoreUnitPropertyPageTest.java
@@ -36,6 +36,8 @@ import static org.mockito.Mockito.mock;
  * Tests {@link MoreUnitPropertyPage} with real SWT widgets.
  */
 @Context(SimpleJUnit4Project.class)
+// white-box test: uses internal types on purpose
+@SuppressWarnings("restriction")
 public class MoreUnitPropertyPageTest extends SwtPageTestCase
 {
     private MoreUnitPropertyPage page;
@@ -276,6 +278,9 @@ public class MoreUnitPropertyPageTest extends SwtPageTestCase
         }
     }
 
+    // Acces reflexif au champ prive "preferenceMap" de Preferences (test uniquement) :
+    // le cast Map<IJavaProject, IPreferenceStore> est sur mais non verifiable a l'execution.
+    @SuppressWarnings("unchecked")
     private IPreferenceStore replaceProjectStoreWithFailingStore() throws Exception
     {
         IPreferenceStore oldStore = Preferences.getInstance().getProjectStore(javaProject);
@@ -296,6 +301,9 @@ public class MoreUnitPropertyPageTest extends SwtPageTestCase
         return oldStore;
     }
 
+    // Acces reflexif au champ prive "preferenceMap" de Preferences (test uniquement) :
+    // le cast Map<IJavaProject, IPreferenceStore> est sur mais non verifiable a l'execution.
+    @SuppressWarnings("unchecked")
     private void restoreProjectStore(IPreferenceStore oldStore) throws Exception
     {
         Field preferenceMapField = Preferences.class.getDeclaredField("preferenceMap");

--- a/org.moreunit.test/test/org/moreunit/properties/OtherMoreunitPropertiesBlockTest.java
+++ b/org.moreunit.test/test/org/moreunit/properties/OtherMoreunitPropertiesBlockTest.java
@@ -35,6 +35,8 @@ import org.moreunit.test.context.configs.SimpleJUnit4Project;
  * project, so no cleanup is required).
  */
 @Context(SimpleJUnit4Project.class)
+// white-box test: uses internal types on purpose
+@SuppressWarnings("restriction")
 public class OtherMoreunitPropertiesBlockTest extends SwtPageTestCase
 {
     private static final String SRC_FILE_VARIABLE = TestFileNamePattern.SRC_FILE_VARIABLE;
@@ -56,7 +58,7 @@ public class OtherMoreunitPropertiesBlockTest extends SwtPageTestCase
         preferences.setTestPackagePrefix(javaProject, "");
         preferences.setTestPackageSuffix(javaProject, "");
         preferences.setTestSuperClass(javaProject, "");
-        preferences.forProject(javaProject).setTestClassNameTemplate(PreferenceConstants.DEFAULT_TEST_CLASS_NAME_TEMPLATE);
+        Preferences.forProject(javaProject).setTestClassNameTemplate(PreferenceConstants.DEFAULT_TEST_CLASS_NAME_TEMPLATE);
         preferences.setTestAnnotationMode(javaProject, TestAnnotationMode.OFF);
         preferences.setShouldUseTestMethodExtendedSearch(javaProject, true);
         preferences.setShouldUseTestMethodSearchByName(javaProject, true);

--- a/org.moreunit.test/test/org/moreunit/properties/SwtPageTestCase.java
+++ b/org.moreunit.test/test/org/moreunit/properties/SwtPageTestCase.java
@@ -163,6 +163,11 @@ public abstract class SwtPageTestCase extends ContextTestCase
     /**
      * Returns the text field placed next to the label having the given text
      * (fields and their labels are consecutive children of their parent).
+     *
+     * @param composite the composite to search (recursively)
+     * @param labelText the text of the label next to the wanted field
+     * @return the text field following the label, or {@code null} if none
+     *         matches
      */
     protected static Text findTextByLabel(Composite composite, String labelText)
     {

--- a/org.moreunit.test/test/org/moreunit/test/support/DialogHelper.java
+++ b/org.moreunit.test/test/org/moreunit/test/support/DialogHelper.java
@@ -36,6 +36,12 @@ public final class DialogHelper
      * {@code knownShells} was captured and then applies the given action. The
      * task gives up after {@code maxAttempts} polls and then closes all new
      * shells, so that the dialog call eventually returns.
+     *
+     * @param display the display on which the dialog will open
+     * @param knownShells the shells existing before the dialog opens
+     * @param action the action to apply to the new shell once detected
+     * @param maxAttempts the number of polls before giving up
+     * @return a task polling for the new dialog shell
      */
     public static Runnable closerFor(Display display, Set<Shell> knownShells, Consumer<Shell> action, int maxAttempts)
     {
@@ -84,6 +90,9 @@ public final class DialogHelper
      * Selects the first tree item whose text contains the given text and
      * confirms it (default selection). Closes the shell when no such item
      * exists.
+     *
+     * @param dialogShell the dialog shell containing the tree
+     * @param itemText the (sub)string identifying the item to confirm
      */
     public static void confirmItem(Shell dialogShell, String itemText)
     {
@@ -123,6 +132,8 @@ public final class DialogHelper
 
     /**
      * Clicks the OK button of a {@link org.eclipse.jface.dialogs.Dialog} shell.
+     *
+     * @param dialogShell the dialog shell containing the OK button
      */
     public static void confirmOkButton(Shell dialogShell)
     {


### PR DESCRIPTION
## Resume

Nettoyage complet des warnings JDT/PDE verifies via serveur MCP Eclipse :
- `eclipse_get_problems(severity=all)` : **112 -> 0**
- `eclipse_build(full)` : **0 errors, 0 warnings**
- `mvn -o clean verify -DskipTests` : **BUILD SUCCESS 15/15**

## Familles traitees

- **PDE (3)** : BREE `org.moreunit.core.test` JavaSE-11 -> 21 (`MANIFEST.MF:6`)
- **rawtypes/unchecked** : `TypeRef<?>`, `TypeUse<?>`, `Collections.emptyList()` (`BaseTools`), `new ArrayList<Annotation>` (`MoreUnitAnnotationModel`)
- **deprecation** : `new URL()` -> `URI.create().toURL()` (5x), `getContextType` suppression minimale documentee
- **unused** : assignations sans effet supprimees (effets de bord gardes), champ mort supprime (`TestFileNamePattern`), methode reflexive conservee (`SearchTools`)
- **restriction/discouraged (~50)** : `@SuppressWarnings(restriction)` niveau classe sur 6 tests white-box
- **javadoc/static** : tags manquants, acces statique `Preferences.forProject`, signature `inputChanged(Viewer)`

## Impact utilisateur

Aucun changement fonctionnel. Code plus strict, IDE sans warnings, build propre.

## Verification

- MCP : `eclipse_get_problems`, `eclipse_build`, `eclipse_mark_problems` diff
- Maven : `mvn -o clean verify -DskipTests -fae`

Hors scope (env IDE, non touche) : erreurs Error Log `claudecode.eclipse`, p2 MCP Server requiert JavaSE-25, warnings m2e sourceRoots Maven 4.