### PR TITLE
ci: cut PR build time ~40% (coverage to master-only, drop -U, pin PMD, concurrency)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,7 +22,6 @@ on:
     paths-ignore:
       - '**/README.md'
 
-# Cheap (build-mode: none) but pointless to run twice on an active PR.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,6 +22,11 @@ on:
     paths-ignore:
       - '**/README.md'
 
+# Cheap (build-mode: none) but pointless to run twice on an active PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,12 +1,19 @@
 name: Coverage
 
+# Full suite incl. SWTBot (~16 min on windows-latest = ~33 billed minutes).
+# Runs on master only: maven.yml already runs every test on PRs, so per-PR
+# coverage only duplicated it. Use "Run workflow" for a manual report.
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
+    paths-ignore: [ '**.md', 'docs/**' ]
+  workflow_dispatch:
 
 permissions: write-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -26,7 +33,7 @@ jobs:
 
 
       - name: Build with Coverage
-        run: mvn -file org.moreunit.build/pom.xml clean install -Pcoverage "-Dtarget.platform.classifier=eclipse-latest" --fail-at-end --batch-mode --strict-checksums --update-snapshots "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+        run: mvn -file org.moreunit.build/pom.xml clean install -Pcoverage "-Dtarget.platform.classifier=eclipse-latest" --fail-at-end --batch-mode --strict-checksums "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,8 +1,5 @@
 name: Coverage
 
-# Full suite incl. SWTBot (~16 min on windows-latest = ~33 billed minutes).
-# Runs on master only: maven.yml already runs every test on PRs, so per-PR
-# coverage only duplicated it. Use "Run workflow" for a manual report.
 on:
   push:
     branches: [ master ]

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,8 +6,18 @@ on:
     tags : ['*']
   pull_request:
     branches: [ master ]
+    # Docs-only PRs need no 10+ min Tycho build (GitHub skips the run only
+    # when *every* changed file matches).
+    paths-ignore: [ '**.md', 'docs/**' ]
 
 permissions: write-all
+
+# Cancel outdated runs of the same workflow on the same ref (active PRs
+# pushing often). Tag/master builds never cancel each other mid-release:
+# each run has its own ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 # bash instead of the default pwsh on Windows runners: pwsh splits unquoted
 # arguments at the first dot (-Dtarget.platform.classifier=... becomes
@@ -19,8 +29,11 @@ defaults:
 
 env:
   # Common flags for every mvn invocation (no internal quotes: the value is
-  # expanded unquoted into the shell command line)
-  MVN_ARGS: --batch-mode --strict-checksums --update-snapshots -Dtarget.platform.classifier=eclipse-latest -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+  # expanded unquoted into the shell command line).
+  # No --update-snapshots: there are no external SNAPSHOT dependencies
+  # (Tycho is pinned, the rest is the reactor), and -U forces p2/metadata
+  # re-checks on each of the 4 mvn invocations of this workflow.
+  MVN_ARGS: --batch-mode --strict-checksums -Dtarget.platform.classifier=eclipse-latest -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
 jobs:
   # Unit tests + packaging + release. The SWTBot tests run in a parallel job
@@ -46,8 +59,10 @@ jobs:
       - name: Build and verify
         run: mvn -file org.moreunit.build/pom.xml clean install ${{ env.MVN_ARGS }} -pl "!org.moreunit.plugins:org.moreunit.swtbot.test" --fail-at-end
 
+      # Pinned version (was: unpinned pmd:check, resolving LATEST metadata on
+      # every run). 3.28.0 is what the unpinned goal resolved to.
       - name: Run PMD and CPD checks
-        run: mvn -file org.moreunit.build/pom.xml pmd:check pmd:cpd-check
+        run: mvn -file org.moreunit.build/pom.xml org.apache.maven.plugins:maven-pmd-plugin:3.28.0:check org.apache.maven.plugins:maven-pmd-plugin:3.28.0:cpd-check
 
       - name: Publish Surefire Test Results for  🖨
         if: ${{ always() }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,15 +6,10 @@ on:
     tags : ['*']
   pull_request:
     branches: [ master ]
-    # Docs-only PRs need no 10+ min Tycho build (GitHub skips the run only
-    # when *every* changed file matches).
     paths-ignore: [ '**.md', 'docs/**' ]
 
 permissions: write-all
 
-# Cancel outdated runs of the same workflow on the same ref (active PRs
-# pushing often). Tag/master builds never cancel each other mid-release:
-# each run has its own ref.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -29,10 +24,7 @@ defaults:
 
 env:
   # Common flags for every mvn invocation (no internal quotes: the value is
-  # expanded unquoted into the shell command line).
-  # No --update-snapshots: there are no external SNAPSHOT dependencies
-  # (Tycho is pinned, the rest is the reactor), and -U forces p2/metadata
-  # re-checks on each of the 4 mvn invocations of this workflow.
+  # expanded unquoted into the shell command line)
   MVN_ARGS: --batch-mode --strict-checksums -Dtarget.platform.classifier=eclipse-latest -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
 jobs:
@@ -59,8 +51,6 @@ jobs:
       - name: Build and verify
         run: mvn -file org.moreunit.build/pom.xml clean install ${{ env.MVN_ARGS }} -pl "!org.moreunit.plugins:org.moreunit.swtbot.test" --fail-at-end
 
-      # Pinned version (was: unpinned pmd:check, resolving LATEST metadata on
-      # every run). 3.28.0 is what the unpinned goal resolved to.
       - name: Run PMD and CPD checks
         run: mvn -file org.moreunit.build/pom.xml org.apache.maven.plugins:maven-pmd-plugin:3.28.0:check org.apache.maven.plugins:maven-pmd-plugin:3.28.0:cpd-check
 


### PR DESCRIPTION
## Analyse (run master 33726050848, 2026-09-03)

| Job | Wall | Contenu |
|---|---|---|
| maven.yml `build` | 9m07 (Maven 7m26) | core 1m40 (incl. resolution target), test.deps 39s, core.test 37s, **org.moreunit.test 2m37**, mock.it 54s, PMD 32s (invocation separee) |
| maven.yml `swtbot-tests` | **11m16 (critique hors coverage)** | install bundles 1m50 (2e resolution target), SWTBot 7m21 |
| coverage.yml | **16m34 (critique global)** | rejoue TOUT incluant swtbot 7m26 -> ne fait que dupliquer maven.yml |
| codeql | ~4m | build-mode none, pas de Maven |

Top classes lentes: `PreferencesTest` 162s + `PreferencesPageSWTBotTest` 144s (dialog Preferences, cf. PR #370), `ClassCreationTest` 35s. Cache Maven: HIT. `Resolving target definition` x3 par invocation -> `--update-snapshots` force des re-checks p2 x4 invocations. PMD non pinne (resout LATEST a chaque run).

## Changements

- **coverage.yml**: plus de trigger `pull_request` (master + `workflow_dispatch`). Economie: ~16.5m wall / ~33 min facturees (windows x2) par PR. Pas de protection de branche requérant ce check (verifie: 404).
- **MVN_ARGS / coverage**: drop `--update-snapshots` (aucune dep SNAPSHOT externe: Tycho 5.0.4 pinne, reste = reacteur).
- **PMD**: plugin pinne `maven-pmd-plugin:3.28.0` (version resolue actuellement) -> reproductible, sans resolution LATEST.
- **concurrency cancel-in-progress** sur les 3 workflows (runs obsoletes des PR actives).
- **paths-ignore md/docs** sur PR (maven) et push master (coverage).

## Gains attendus par PR

- Wall: ~16.5m -> ~10-11m (**-35-40%**), le critique devient swtbot-tests.
- Minutes facturees: -~33 (coverage) - ~5% sur les resolutions p2 restantes.

## Non retenu (risque/complexite)

- Fusion install+verify SWTBot en un reacteur: Tycho ne resout pas Require-Bundle depuis le reacteur (cf. commentaire workflow + skill) -> casse garantie.
- Runner ubuntu pour le job build: -20-30% possibles mais tests UI sur OS different, non valide localement.
- Sharding SWTBot / regroupement PreferencesTest: follow-ups possibles, chiffres en analyse.

## Validation

- Ce PR fait tourner build+swtbot+codeql (triggers PR intacts) -> non-regression prouvee par le CI lui-meme.
- coverage.yml valide au merge sur master.