### PR TITLE
fix(tests): harden dialog-driven UI tests against focus loss on shared displays

### DIFF
--- a/org.moreunit.plugin/src/org/moreunit/ui/ChooseDialog.java
+++ b/org.moreunit.plugin/src/org/moreunit/ui/ChooseDialog.java
@@ -65,6 +65,25 @@ public class ChooseDialog<T> extends PopupDialog implements DisposeListener
     }
 
     @Override
+    protected Control getFocusControl()
+    {
+        // PopupDialog.open() dereferences this without a null check; the tree
+        // is the dialog area, so focusing it preserves the default behavior
+        // while staying safe when creation was interrupted (seen as an NPE on
+        // GTK when the shell lifecycle races with its opener).
+        if(treeViewer != null)
+        {
+            final Tree tree = treeViewer.getTree();
+            if(tree != null && ! tree.isDisposed())
+            {
+                return tree;
+            }
+        }
+        final Shell shell = getShell();
+        return shell != null && ! shell.isDisposed() ? shell : null;
+    }
+
+    @Override
     protected Control createDialogArea(Composite parent)
     {
         treeViewer = createTreeViewer(parent);

--- a/org.moreunit.test/test/org/moreunit/elements/ClassTypeFacadeTest.java
+++ b/org.moreunit.test/test/org/moreunit/elements/ClassTypeFacadeTest.java
@@ -320,7 +320,7 @@ public class ClassTypeFacadeTest extends ContextTestCase
     {
         final Display display = Display.getDefault();
         final java.util.Set<Shell> knownShells = DialogHelper.knownShells(display);
-        display.asyncExec(DialogHelper.closerFor(display, knownShells, shell -> DialogHelper.confirmItem(shell, "FooTest"), 2000));
+        display.asyncExec(DialogHelper.closerUntilHandled(display, knownShells, shell -> DialogHelper.confirmItem(shell, "FooTest"), 2000));
 
         final ClassTypeFacade classTypeFacade = new ClassTypeFacade(context.getCompilationUnit("com.Foo"));
         final ClassTypeFacade.CorrespondingTestCase result = classTypeFacade.getOneCorrespondingTestCase(false, "Please choose a test case...");
@@ -342,7 +342,7 @@ public class ClassTypeFacadeTest extends ContextTestCase
 
         final Display display = Display.getDefault();
         final java.util.Set<Shell> knownShells = DialogHelper.knownShells(display);
-        display.asyncExec(DialogHelper.closerFor(display, knownShells, shell -> DialogHelper.confirmItem(shell, "testGiveMe1"), 2000));
+        display.asyncExec(DialogHelper.closerUntilHandled(display, knownShells, shell -> DialogHelper.confirmItem(shell, "testGiveMe1"), 2000));
 
         final TypeFacade classTypeFacade = new ClassTypeFacade(cutHandler().getCompilationUnit());
         final CorrespondingMemberRequest request = newCorrespondingMemberRequest() //

--- a/org.moreunit.test/test/org/moreunit/elements/TypeFacadeTest.java
+++ b/org.moreunit.test/test/org/moreunit/elements/TypeFacadeTest.java
@@ -95,7 +95,7 @@ public class TypeFacadeTest extends ContextTestCase
         // the test class lives in another package: it is a likely, not a perfect, match
         final Display display = Display.getDefault();
         final java.util.Set<Shell> knownShells = DialogHelper.knownShells(display);
-        display.asyncExec(DialogHelper.closerFor(display, knownShells, shell -> DialogHelper.confirmItem(shell, "FooTest"), 2000));
+        display.asyncExec(DialogHelper.closerUntilHandled(display, knownShells, shell -> DialogHelper.confirmItem(shell, "FooTest"), 2000));
 
         final ClassTypeFacade facade = new ClassTypeFacade(context.getCompilationUnit("com.Foo"));
 

--- a/org.moreunit.test/test/org/moreunit/handler/RunTestsActionExecutorTest.java
+++ b/org.moreunit.test/test/org/moreunit/handler/RunTestsActionExecutorTest.java
@@ -39,6 +39,7 @@ import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPartSite;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.moreunit.launch.TestLauncher;
 import org.moreunit.test.support.DialogHelper;
 import org.moreunit.test.context.ContextTestCase;
@@ -97,6 +98,34 @@ public class RunTestsActionExecutorTest extends ContextTestCase
             Thread.sleep(10);
         }
         assertTrue(launchCalled.get(), "TestLauncher.launch was not called");
+    }
+
+    /**
+     * Runs a dialog-driven interaction, waiting briefly for the launch after
+     * each attempt. On a shared desktop the ChooseDialog can be dismissed by
+     * an unrelated focus change before the test driver confirms the choice;
+     * such an attempt launches nothing and is simply retried. A genuinely
+     * broken interaction still fails loudly once attempts run out.
+     */
+    private void awaitLaunchWithRetry(Executable interaction) throws Throwable
+    {
+        Throwable lastFailure = null;
+        for (int attempt = 1; attempt <= 3; attempt++)
+        {
+            launchCalled.set(false);
+            launchedMembers.set(null);
+            interaction.execute();
+            try
+            {
+                awaitLaunch(20_000);
+                return;
+            }
+            catch (final AssertionError e)
+            {
+                lastFailure = e;
+            }
+        }
+        throw lastFailure;
     }
 
     private List<String> launchedElementNames()
@@ -266,20 +295,23 @@ public class RunTestsActionExecutorTest extends ContextTestCase
 
     @Test
     @Preferences(testClassNameTemplate = "${srcFile}*Test", testSrcFolder = "test")
-    public void executeRunTestAction_should_let_the_user_choose_a_concrete_subclass_of_an_abstract_test_case() throws Exception
+    public void executeRunTestAction_should_let_the_user_choose_a_concrete_subclass_of_an_abstract_test_case() throws Throwable
     {
         TypeHandlerAccess.createAbstractTest(context, "com.FooAbstractTest");
         TypeHandlerAccess.createSubclass(context, "com.FooAbstractTest", "com.FooAbstractTestImpl");
         TypeHandlerAccess.createSubclass(context, "com.FooAbstractTest", "com.FooAbstractTestImpl2");
 
         final Display display = Display.getDefault();
-        final java.util.Set<Shell> knownShells = DialogHelper.knownShells(display);
-        display.asyncExec(DialogHelper.closerFor(display, knownShells, //
-                shell -> DialogHelper.confirmItem(shell, "FooAbstractTestImpl"), 2000));
 
-        RunTestsActionExecutor.getInstance().executeRunTestAction(context.getCompilationUnit("com.Foo"), ILaunchManager.RUN_MODE);
+        awaitLaunchWithRetry(() -> {
+            final java.util.Set<Shell> knownShells = DialogHelper.knownShells(display);
+            DialogHelper.bringWorkbenchToFront(display);
+            display.asyncExec(DialogHelper.closerUntilHandled(display, knownShells, //
+                    shell -> DialogHelper.confirmItem(shell, "FooAbstractTestImpl"), 2000));
 
-        awaitLaunch(90_000);
+            RunTestsActionExecutor.getInstance().executeRunTestAction(context.getCompilationUnit("com.Foo"), ILaunchManager.RUN_MODE);
+        });
+
         final List<String> launchedNames = launchedElementNames();
         assertTrue(launchedNames.contains("FooTest"));
         assertTrue(launchedNames.contains("FooAbstractTestImpl"), "chosen subclass should be launched: " + launchedNames);
@@ -288,7 +320,7 @@ public class RunTestsActionExecutorTest extends ContextTestCase
 
     @Test
     @Preferences(testClassNameTemplate = "${srcFile}*Test", testSrcFolder = "test")
-    public void executeRunTestsOfSelectedMemberAction_should_replace_abstract_test_method_by_chosen_subclass_method() throws Exception
+    public void executeRunTestsOfSelectedMemberAction_should_replace_abstract_test_method_by_chosen_subclass_method() throws Throwable
     {
         TypeHandlerAccess.createAbstractTest(context, "com.FooAbstractTest");
         context.getPrimaryTypeHandler("com.FooAbstractTest").addMethod("@Test\npublic void testFoo()", "");
@@ -300,13 +332,15 @@ public class RunTestsActionExecutorTest extends ContextTestCase
         final IEditorPart editorPart = editorOver(context.getCompilationUnit("com.FooAbstractTest"), abstractTestMethod.getNameRange());
 
         final Display display = Display.getDefault();
-        final java.util.Set<Shell> knownShells = DialogHelper.knownShells(display);
-        display.asyncExec(DialogHelper.closerFor(display, knownShells, //
-                shell -> DialogHelper.confirmItem(shell, "FooAbstractTestImpl"), 2000));
+        awaitLaunchWithRetry(() -> {
+            final java.util.Set<Shell> knownShells = DialogHelper.knownShells(display);
+            DialogHelper.bringWorkbenchToFront(display);
+            display.asyncExec(DialogHelper.closerUntilHandled(display, knownShells, //
+                    shell -> DialogHelper.confirmItem(shell, "FooAbstractTestImpl"), 2000));
 
-        RunTestsActionExecutor.getInstance().executeRunTestsOfSelectedMemberAction(editorPart, ILaunchManager.RUN_MODE);
+            RunTestsActionExecutor.getInstance().executeRunTestsOfSelectedMemberAction(editorPart, ILaunchManager.RUN_MODE);
+        });
 
-        awaitLaunch(90_000);
         final List<String> launchedNames = launchedElementNames();
         assertEquals(1, launchedNames.size());
         final IJavaElement launched = launchedMembers.get().iterator().next();
@@ -316,7 +350,7 @@ public class RunTestsActionExecutorTest extends ContextTestCase
 
     @Test
     @Preferences(testClassNameTemplate = "${srcFile}*Test", testSrcFolder = "test")
-    public void executeRunTestsOfSelectedMemberAction_should_launch_all_concrete_subclasses_when_user_chooses_all() throws Exception
+    public void executeRunTestsOfSelectedMemberAction_should_launch_all_concrete_subclasses_when_user_chooses_all() throws Throwable
     {
         TypeHandlerAccess.createAbstractTest(context, "com.FooAbstractTest");
         context.getPrimaryTypeHandler("com.FooAbstractTest").addMethod("@Test\npublic void testFoo()", "");
@@ -329,13 +363,15 @@ public class RunTestsActionExecutorTest extends ContextTestCase
         final IEditorPart editorPart = editorOver(context.getCompilationUnit("com.FooAbstractTest"), abstractTestMethod.getNameRange());
 
         final Display display = Display.getDefault();
-        final java.util.Set<Shell> knownShells = DialogHelper.knownShells(display);
-        display.asyncExec(DialogHelper.closerFor(display, knownShells, //
-                shell -> DialogHelper.confirmItem(shell, "All concrete subclasses"), 2000));
+        awaitLaunchWithRetry(() -> {
+            final java.util.Set<Shell> knownShells = DialogHelper.knownShells(display);
+            DialogHelper.bringWorkbenchToFront(display);
+            display.asyncExec(DialogHelper.closerUntilHandled(display, knownShells, //
+                    shell -> DialogHelper.confirmItem(shell, "All concrete subclasses"), 2000));
 
-        RunTestsActionExecutor.getInstance().executeRunTestsOfSelectedMemberAction(editorPart, ILaunchManager.RUN_MODE);
+            RunTestsActionExecutor.getInstance().executeRunTestsOfSelectedMemberAction(editorPart, ILaunchManager.RUN_MODE);
+        });
 
-        awaitLaunch(90_000);
         final java.util.Set<String> declaringTypes = launchedMembers.get().stream() //
                 .map(e -> ((IMethod) e).getDeclaringType().getElementName()) //
                 .collect(java.util.stream.Collectors.toSet());

--- a/org.moreunit.test/test/org/moreunit/properties/SourceFolderMappingDialogTest.java
+++ b/org.moreunit.test/test/org/moreunit/properties/SourceFolderMappingDialogTest.java
@@ -37,7 +37,7 @@ public class SourceFolderMappingDialogTest extends ContextTestCase
         final Display display = Display.getDefault();
         final Shell dialogParent = new Shell(display);
         final java.util.Set<Shell> knownShells = DialogHelper.knownShells(display);
-        display.asyncExec(DialogHelper.closerFor(display, knownShells, shell -> DialogHelper.confirmOkButton(shell), 2000));
+        display.asyncExec(DialogHelper.closerUntilHandled(display, knownShells, shell -> DialogHelper.confirmOkButton(shell), 2000));
         try
         {
             SourceFolderMappingDialog.open(block, dialogParent, mapping);

--- a/org.moreunit.test/test/org/moreunit/test/support/DialogHelper.java
+++ b/org.moreunit.test/test/org/moreunit/test/support/DialogHelper.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
@@ -31,11 +32,38 @@ public final class DialogHelper
     }
 
     /**
+     * Brings the test workbench window to the front. Call this right before
+     * triggering an action that opens a dialog: on a shared desktop the
+     * workbench may sit behind other windows, and opening a popup there can
+     * deactivate (and thereby dismiss) it before the test driver even sees
+     * it. Must be called on the UI thread.
+     *
+     * @param display the display on which the test workbench runs
+     */
+    public static void bringWorkbenchToFront(Display display)
+    {
+        display.syncExec(() -> {
+            for (final Shell shell : display.getShells())
+            {
+                if(! shell.isDisposed() && shell.isVisible())
+                {
+                    shell.forceActive();
+                }
+            }
+        });
+    }
+
+    /**
      * Returns a task (to be scheduled with {@code display.asyncExec(...)}
      * before the dialog opens) that polls for a shell appearing after
      * {@code knownShells} was captured and then applies the given action. The
      * task gives up after {@code maxAttempts} polls and then closes all new
      * shells, so that the dialog call eventually returns.
+     * <p>
+     * The action runs exactly once, on the first new shell seen. When the
+     * handling depends on the shell content (which may lag behind shell
+     * visibility on some platforms), prefer
+     * {@link #closerUntilHandled(Display, Set, Predicate, int)}.
      *
      * @param display the display on which the dialog will open
      * @param knownShells the shells existing before the dialog opens
@@ -45,12 +73,47 @@ public final class DialogHelper
      */
     public static Runnable closerFor(Display display, Set<Shell> knownShells, Consumer<Shell> action, int maxAttempts)
     {
+        return closerUntilHandled(display, knownShells, shell -> {
+            action.accept(shell);
+            return true;
+        }, maxAttempts);
+    }
+
+    /**
+     * Returns a task (to be scheduled with {@code display.asyncExec(...)}
+     * before the dialog opens) that polls for a shell appearing after
+     * {@code knownShells} was captured and then applies the given action. When
+     * the action reports the shell as not handled yet (for instance its
+     * content is still loading), polling continues until {@code maxAttempts}
+     * polls; then all new shells are closed so that the dialog call
+     * eventually returns.
+     *
+     * @param display the display on which the dialog will open
+     * @param knownShells the shells existing before the dialog opens
+     * @param handled tests a new shell, handling it when ready; {@code true}
+     *            means handled (polling stops), {@code false} means not ready
+     *            yet (polling continues)
+     * @param maxAttempts the number of polls before giving up
+     * @return a task polling for the new dialog shell
+     */
+    public static Runnable closerUntilHandled(Display display, Set<Shell> knownShells, Predicate<Shell> handled, int maxAttempts)
+    {
         return () -> {
             final Shell target = findNewShell(display, knownShells);
             if(target != null)
             {
-                action.accept(target);
-                return;
+                // Keep the focus on the dialog while driving it: ChooseDialog
+                // dismisses itself on deactivation, and on a shared desktop
+                // any focus change in between would silently cancel the
+                // dialog (flaky on GTK, where focus handling is async).
+                if(! target.isDisposed())
+                {
+                    target.forceActive();
+                }
+                if(! target.isDisposed() && handled.test(target))
+                {
+                    return;
+                }
             }
             if(maxAttempts <= 0)
             {
@@ -65,7 +128,7 @@ public final class DialogHelper
                 }
                 return;
             }
-            display.timerExec(20, DialogHelper.closerFor(display, knownShells, action, maxAttempts - 1));
+            display.timerExec(20, DialogHelper.closerUntilHandled(display, knownShells, handled, maxAttempts - 1));
         };
     }
 
@@ -83,28 +146,45 @@ public final class DialogHelper
 
     /**
      * Selects the first tree item whose text contains the given text and
-     * confirms it (default selection). Closes the shell when no such item
-     * exists.
+     * confirms it (default selection).
      *
      * @param dialogShell the dialog shell containing the tree
      * @param itemText the (sub)string identifying the item to confirm
+     * @return {@code true} when an item was confirmed or the shell was closed
+     *         because no item will ever match; {@code false} when the tree
+     *         does not exist yet or its labels are not computed yet, meaning
+     *         the caller should try again later
      */
-    public static void confirmItem(Shell dialogShell, String itemText)
+    public static boolean confirmItem(Shell dialogShell, String itemText)
     {
         final Tree tree = findTree(dialogShell);
-        if(tree == null)
+        if(tree == null || tree.isDisposed())
         {
-            dialogShell.close();
-            return;
+            return false;
         }
-        for (final TreeItem item : tree.getItems())
+        final TreeItem[] items = tree.getItems();
+        if(items.length == 0)
+        {
+            return false;
+        }
+        boolean allLabeled = true;
+        for (final TreeItem item : items)
         {
             if(confirmItemOrChild(item, itemText))
             {
-                return;
+                return true;
+            }
+            if(item.isDisposed() || item.getText().isEmpty())
+            {
+                allLabeled = false;
             }
         }
+        if(! allLabeled)
+        {
+            return false;
+        }
         dialogShell.close();
+        return true;
     }
 
     private static boolean confirmItemOrChild(TreeItem item, String itemText)
@@ -129,16 +209,18 @@ public final class DialogHelper
      * Clicks the OK button of a {@link org.eclipse.jface.dialogs.Dialog} shell.
      *
      * @param dialogShell the dialog shell containing the OK button
+     * @return {@code true} when the button was clicked; {@code false} when it
+     *         does not exist yet, meaning the caller should try again later
      */
-    public static void confirmOkButton(Shell dialogShell)
+    public static boolean confirmOkButton(Shell dialogShell)
     {
         final org.eclipse.swt.widgets.Button okButton = findButtonWithText(dialogShell, "OK");
         if(okButton != null)
         {
             okButton.notifyListeners(org.eclipse.swt.SWT.Selection, new Event());
-            return;
+            return true;
         }
-        dialogShell.close();
+        return false;
     }
 
     private static org.eclipse.swt.widgets.Button findButtonWithText(org.eclipse.swt.widgets.Widget widget, String text)

--- a/org.moreunit.test/test/org/moreunit/ui/ChooseDialogTest.java
+++ b/org.moreunit.test/test/org/moreunit/ui/ChooseDialogTest.java
@@ -313,7 +313,7 @@ public class ChooseDialogTest extends SwtPageTestCase
 
         final Set<Shell> knownShells = DialogHelper.knownShells(display);
         knownShells.remove(dialog.getShell()); // the popup shell already exists
-        display.asyncExec(DialogHelper.closerFor(display, knownShells, shell -> DialogHelper.confirmItem(shell, "Type2"), 2000));
+        display.asyncExec(DialogHelper.closerUntilHandled(display, knownShells, shell -> DialogHelper.confirmItem(shell, "Type2"), 2000));
 
         final java.util.concurrent.atomic.AtomicReference<Object> choice = new java.util.concurrent.atomic.AtomicReference<>();
         final Thread background = new Thread(() -> choice.set(Display.getDefault().syncCall(dialog::getChoice)));


### PR DESCRIPTION
## Probleme

Sur desktop Linux partage (:0 avec un IDE actif), `RunTestsActionExecutorTest..._when_user_chooses_all` echouait systematiquement (timeout 90s, `launch` jamais appele), avec une variante NPE `PopupDialog.getFocusControl()` (verifie au bytecode: `open()` dereference sans garde-fou). CI Windows: vert (session dediee, pas de vol de focus).

Mecanisme: le helper fermait le dialogue avant que son contenu existe (fenetre visible avant widgets sur GTK), ou le dialogue etait auto-ferme par defaut de focus (style info-popup) avant/apres ouverture.

## Changements

- `DialogHelper.closerUntilHandled` (Predicate): reessaie tant que l'arbre est absent/vide/non labellise au lieu de fermer; force le focus sur le dialogue conduit; les sites `Shell::close` gardent `closerFor`
- `confirmItem`/`confirmOkButton` -> boolean (pret / pas pret)
- `RunTestsActionExecutorTest`: retry borne (3x20s) sur les 3 tests a dialogue; un echec reel echoue toujours bruyamment
- `ChooseDialog.getFocusControl()` surcharge (arbre, null-safe; meme controle qu'avant en flux normal)

## Validation

- Local Linux + UI: `org.moreunit.test` 712/712, `mock.test` 433/433, BUILD SUCCESS (avant: 712/1 echec + NPE)
- MCP: 0 probleme JDT
- CI de cette PR (Windows) confirmera l'absence de regression