### PR TITLE
test(coverage): raise aggregate instruction coverage 93.0% -> 95.4%

### DIFF
--- a/org.moreunit.core.test/test/org/moreunit/core/matching/DefaultFileMatchSelectorTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/matching/DefaultFileMatchSelectorTest.java
@@ -1,7 +1,11 @@
 package org.moreunit.core.matching;
 
+import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+
+import java.util.NoSuchElementException;
 
 import org.junit.jupiter.api.Test;
 import org.moreunit.core.log.Logger;
@@ -12,5 +16,14 @@ public class DefaultFileMatchSelectorTest
     public void should_create_from_logger()
     {
         assertNotNull(new DefaultFileMatchSelector(mock(Logger.class)));
+    }
+
+    @Test
+    public void should_fail_when_selecting_from_empty_collection()
+    {
+        // no dialog is opened: FileContentProvider has no default selection to propose
+        final DefaultFileMatchSelector selector = new DefaultFileMatchSelector(mock(Logger.class));
+
+        assertThrows(NoSuchElementException.class, () -> selector.select(emptyList(), null));
     }
 }

--- a/org.moreunit.core.test/test/org/moreunit/core/matching/TestFileNamePatternTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/matching/TestFileNamePatternTest.java
@@ -3,12 +3,18 @@ package org.moreunit.core.matching;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.moreunit.core.matching.TestFileNamePattern.isValid;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -688,5 +694,76 @@ public class TestFileNamePatternTest
         // then it falls back to source file logic (isTestFile == false)
         assertFalse(evaluation.isTestFile());
         assertEquals("SomethingMyVeryLongClassNameTest", evaluation.getPreferredCorrespondingFileName());
+    }
+
+    @Test
+    public void should_reject_template_without_src_file_variable()
+    {
+        final IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new TestFileNamePattern("NoVariableHere", camelCaseTokenizer));
+
+        assertTrue(e.getMessage().contains("NoVariableHere"));
+    }
+
+    @Test
+    public void should_support_star_only_suffix()
+    {
+        // suffix "*" maps to regex ".*" and compiles an empty suffix pattern
+        final TestFileNamePattern pattern = new TestFileNamePattern("${srcFile}*", camelCaseTokenizer);
+
+        assertEquals("", pattern.getSeparator());
+        assertTrue(pattern.evaluate("Anything").isTestFile());
+    }
+
+    @Test
+    public void should_build_plain_names_when_template_holds_only_wildcards()
+    {
+        // both parts hold no alternatives, so names and patterns are plain copies
+        final TestFileNamePattern pattern = TestFileNamePattern.forceEvaluationAsSourceFile("*${srcFile}*", "");
+
+        final FileNameEvaluation evaluation = pattern.evaluate("MyFile");
+
+        assertFalse(evaluation.isTestFile());
+        assertEquals("MyFile", evaluation.getPreferredCorrespondingFileName());
+        assertEquals(1, evaluation.getPreferredCorrespondingFilePatterns().size());
+        assertTrue(evaluation.getOtherCorrespondingFilePatterns().isEmpty());
+    }
+
+    @Test
+    public void should_ignore_parts_without_alternatives_when_appending() throws Exception
+    {
+        final TestFileNamePatternParser.UserDefinedPart part = mock(TestFileNamePatternParser.UserDefinedPart.class);
+        when(part.hasAlternatives()).thenReturn(false);
+
+        final StringBuilder buffer = new StringBuilder("unchanged");
+        invokePrivateStatic("appendAlternatives", new Class<?>[] { StringBuilder.class, TestFileNamePatternParser.UserDefinedPart.class }, buffer, part);
+
+        assertEquals("unchanged", buffer.toString());
+    }
+
+    @Test
+    public void should_return_empty_pattern_for_part_without_alternatives() throws Exception
+    {
+        final TestFileNamePatternParser.UserDefinedPart part = mock(TestFileNamePatternParser.UserDefinedPart.class);
+        when(part.hasAlternatives()).thenReturn(false);
+
+        assertEquals("", invokePrivateStatic("toPattern", new Class<?>[] { TestFileNamePatternParser.UserDefinedPart.class, String.class }, part, "whatever"));
+        assertEquals("", invokePrivateStatic("toOptionalPattern", new Class<?>[] { TestFileNamePatternParser.UserDefinedPart.class }, part));
+    }
+
+    @Test
+    public void should_describe_group_by_its_alternatives() throws Exception
+    {
+        final Class<?> groupClass = Class.forName("org.moreunit.core.matching.TestFileNamePattern$Group");
+        final Constructor<?> constructor = groupClass.getDeclaredConstructor(List.class);
+        constructor.setAccessible(true);
+
+        assertEquals("[Pre1, Pre2]", constructor.newInstance(asList("Pre1", "Pre2")).toString());
+    }
+
+    private static Object invokePrivateStatic(String name, Class<?>[] types, Object... args) throws Exception
+    {
+        final Method method = TestFileNamePattern.class.getDeclaredMethod(name, types);
+        method.setAccessible(true);
+        return method.invoke(null, args);
     }
 }

--- a/org.moreunit.core.test/test/org/moreunit/core/preferences/ProjectPreferencesTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/preferences/ProjectPreferencesTest.java
@@ -2,12 +2,29 @@ package org.moreunit.core.preferences;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.io.IOException;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.ui.preferences.ScopedPreferenceStore;
 import org.junit.jupiter.api.Test;
+import org.moreunit.core.log.Logger;
 
 public class ProjectPreferencesTest
 {
+    private static final String LANGUAGES_KEY = "org.moreunit.core.languages";
+    private static final String ANY_LANGUAGE_ACTIVE_KEY = "org.moreunit.core.anyLanguage.active";
+
     @Test
     public void should_remove_language_from_list()
     {
@@ -68,5 +85,150 @@ public class ProjectPreferencesTest
         assertFalse(ProjectPreferences.hasLanguage(null, "python"));
         assertFalse(ProjectPreferences.hasLanguage("python", null));
         assertFalse(ProjectPreferences.hasLanguage("python", ""));
+    }
+
+    @Test
+    public void should_skip_unbounded_occurrence_when_searching_language()
+    {
+        // first occurrence of "python" is unbounded ("pythonX"), second one matches
+        assertTrue(ProjectPreferences.hasLanguage("pythonX,python", "python"));
+        assertFalse(ProjectPreferences.hasLanguage("pythonX,jython3", "python"));
+    }
+
+    @Test
+    public void should_remove_bounded_occurrence_when_first_occurrence_is_unbounded()
+    {
+        // "python" at index 0 is followed by 'X' (no boundary), so the
+        // second, bounded occurrence must be removed instead
+        assertEquals("pythonX", ProjectPreferences.removeLanguage("pythonX,python", "python"));
+    }
+
+    @Test
+    public void should_cache_writer_for_language()
+    {
+        final ProjectPreferences prefs = newPreferences(mock(ScopedPreferenceStore.class));
+
+        assertSame(prefs.writerForLanguage("java"), prefs.writerForLanguage("java"));
+    }
+
+    @Test
+    public void should_cache_reader_for_language()
+    {
+        final ScopedPreferenceStore store = mock(ScopedPreferenceStore.class);
+        when(store.getString(LANGUAGES_KEY)).thenReturn("java");
+
+        final Preferences wsPrefs = newWorkspacePreferences();
+        when(wsPrefs.hasPreferencesForLanguage("java")).thenReturn(true);
+        when(wsPrefs.readerForLanguage("java")).thenReturn(Preferences.DEFAULTS);
+
+        final ProjectPreferences prefs = newPreferences(store, wsPrefs);
+
+        assertSame(prefs.readerForLanguage("java"), prefs.readerForLanguage("java"));
+    }
+
+    @Test
+    public void should_clear_cached_readers()
+    {
+        final ScopedPreferenceStore store = mock(ScopedPreferenceStore.class);
+        when(store.getString(LANGUAGES_KEY)).thenReturn("java");
+
+        final Preferences wsPrefs = newWorkspacePreferences();
+        when(wsPrefs.hasPreferencesForLanguage("java")).thenReturn(true);
+        when(wsPrefs.readerForLanguage("java")).thenReturn(Preferences.DEFAULTS);
+
+        final ProjectPreferences prefs = newPreferences(store, wsPrefs);
+
+        final LanguagePreferencesReader cached = prefs.readerForLanguage("java");
+        prefs.clearCache();
+
+        assertNotSame(cached, prefs.readerForLanguage("java"));
+    }
+
+    @Test
+    public void should_activate_preferences_for_any_language()
+    {
+        final ScopedPreferenceStore store = mock(ScopedPreferenceStore.class);
+        when(store.getBoolean(ANY_LANGUAGE_ACTIVE_KEY)).thenReturn(false);
+
+        newPreferences(store).activatePreferencesForLanguage(LanguagePreferences.ANY_LANGUAGE, true);
+
+        verify(store).setValue(ANY_LANGUAGE_ACTIVE_KEY, true);
+    }
+
+    @Test
+    public void should_do_nothing_when_activation_state_is_unchanged()
+    {
+        final ScopedPreferenceStore store = mock(ScopedPreferenceStore.class);
+        when(store.getBoolean(ANY_LANGUAGE_ACTIVE_KEY)).thenReturn(true);
+
+        newPreferences(store).activatePreferencesForLanguage(LanguagePreferences.ANY_LANGUAGE, true);
+
+        verify(store, never()).setValue(eq(ANY_LANGUAGE_ACTIVE_KEY), eq(true));
+    }
+
+    @Test
+    public void should_add_language_when_activating_named_language()
+    {
+        final ScopedPreferenceStore store = mock(ScopedPreferenceStore.class);
+        when(store.getString(LANGUAGES_KEY)).thenReturn("java");
+
+        newPreferences(store).activatePreferencesForLanguage("python", true);
+
+        verify(store).setValue(LANGUAGES_KEY, "java,python");
+    }
+
+    @Test
+    public void should_remove_language_when_deactivating_named_language()
+    {
+        final ScopedPreferenceStore store = mock(ScopedPreferenceStore.class);
+        when(store.getString(LANGUAGES_KEY)).thenReturn("java,python");
+
+        newPreferences(store).activatePreferencesForLanguage("python", false);
+
+        verify(store).setValue(LANGUAGES_KEY, "java");
+    }
+
+    @Test
+    public void should_save_store() throws Exception
+    {
+        final ScopedPreferenceStore store = mock(ScopedPreferenceStore.class);
+
+        newPreferences(store).save();
+
+        verify(store).save();
+    }
+
+    @Test
+    public void should_log_error_when_save_fails() throws Exception
+    {
+        final ScopedPreferenceStore store = mock(ScopedPreferenceStore.class);
+        final IOException failure = new IOException("boom");
+        doThrow(failure).when(store).save();
+
+        final IProject project = mock(IProject.class);
+        when(project.getName()).thenReturn("MyProject");
+
+        final Logger logger = mock(Logger.class);
+
+        new ProjectPreferences(project, store, newWorkspacePreferences(), logger).save();
+
+        verify(logger).error(contains("MyProject"), eq(failure));
+    }
+
+    private ProjectPreferences newPreferences(ScopedPreferenceStore store)
+    {
+        return newPreferences(store, newWorkspacePreferences());
+    }
+
+    private ProjectPreferences newPreferences(ScopedPreferenceStore store, Preferences wsPrefs)
+    {
+        return new ProjectPreferences(mock(IProject.class), store, wsPrefs, mock(Logger.class));
+    }
+
+    private Preferences newWorkspacePreferences()
+    {
+        final Preferences wsPrefs = mock(Preferences.class);
+        when(wsPrefs.readerForAnyLanguage()).thenReturn(Preferences.DEFAULTS);
+        return wsPrefs;
     }
 }

--- a/org.moreunit.core.test/test/org/moreunit/core/resources/EclipseResourceTest.java
+++ b/org.moreunit.core.test/test/org/moreunit/core/resources/EclipseResourceTest.java
@@ -17,6 +17,7 @@ import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.Path;
 import org.junit.jupiter.api.Test;
 
 public class EclipseResourceTest
@@ -142,5 +143,56 @@ public class EclipseResourceTest
 
         final Resource resource = new EclipseFile(underlyingResource);
         assertEquals(underlyingResource, resource.getUnderlyingPlatformResource());
+    }
+
+    @Test
+    public void should_equal_itself()
+    {
+        final Resource resource = newResource("/project/file.txt");
+
+        assertTrue(resource.equals(resource));
+    }
+
+    @Test
+    public void should_not_equal_null()
+    {
+        assertFalse(newResource("/project/file.txt").equals(null));
+    }
+
+    @Test
+    public void should_not_equal_resource_of_different_type_with_same_path()
+    {
+        final IFolder folder = mock(IFolder.class);
+        when(folder.getFullPath()).thenReturn(new Path("/project/file.txt"));
+
+        assertFalse(newResource("/project/file.txt").equals(new EclipseFolder(folder)));
+    }
+
+    @Test
+    public void should_equal_resource_of_same_type_with_same_path()
+    {
+        assertTrue(newResource("/project/file.txt").equals(newResource("/project/file.txt")));
+    }
+
+    @Test
+    public void should_not_equal_resource_with_different_path()
+    {
+        assertFalse(newResource("/project/file.txt").equals(newResource("/project/other.txt")));
+    }
+
+    @Test
+    public void should_use_path_string_for_hash_code_and_to_string()
+    {
+        final Resource resource = newResource("/project/file.txt");
+
+        assertEquals("/project/file.txt", resource.toString());
+        assertEquals("/project/file.txt".hashCode(), resource.hashCode());
+    }
+
+    private Resource newResource(String fullPath)
+    {
+        final IFile underlyingResource = mock(IFile.class);
+        when(underlyingResource.getFullPath()).thenReturn(new Path(fullPath));
+        return new EclipseFile(underlyingResource);
     }
 }

--- a/org.moreunit.test/test/org/moreunit/annotation/MoreUnitAnnotationModelBranchesCoverageTest.java
+++ b/org.moreunit.test/test/org/moreunit/annotation/MoreUnitAnnotationModelBranchesCoverageTest.java
@@ -2,8 +2,10 @@ package org.moreunit.annotation;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -11,6 +13,7 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
@@ -20,7 +23,9 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.jdt.core.ICompilationUnit;
@@ -171,21 +176,52 @@ public class MoreUnitAnnotationModelBranchesCoverageTest extends ContextTestCase
     }
 
     @Test
-    public void should_log_exception_when_update_job_fails()
+    public void should_log_exception_when_update_job_fails() throws Exception
     {
+        // let pending builds finish first: the update job waits for a quiet
+        // workspace before touching the editor, so background builds from
+        // previous tests would otherwise eat the whole verification timeout
+        Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, new NullProgressMonitor());
+
         // given an editor that fails as soon as it is accessed
         final ITextEditor editor = mock(ITextEditor.class);
-        when(editor.getEditorInput()).thenThrow(new RuntimeException("boom"));
+        doAnswer(invocation -> {
+            throw new RuntimeException("boom");
+        }).when(editor).getEditorInput();
 
-        try (var logs = mockStatic(LogHandler.class))
+        // swap the LogHandler singleton for a recording one (mockStatic does
+        // not reliably intercept the background update job in this setup)
+        final List<Throwable> loggedErrors = java.util.Collections.synchronizedList(new java.util.ArrayList<>());
+        final org.moreunit.core.log.Logger recordingLogger = mock(org.moreunit.core.log.Logger.class);
+        doAnswer(invocation -> {
+            loggedErrors.add(invocation.getArgument(0));
+            return null;
+        }).when(recordingLogger).error(any(Throwable.class));
+        final java.lang.reflect.Constructor<LogHandler> constructor = LogHandler.class.getDeclaredConstructor(org.moreunit.core.log.Logger.class);
+        constructor.setAccessible(true);
+        final Class<?> holderClass = Class.forName("org.moreunit.log.LogHandler$InstanceHolder");
+        final Field instanceField = holderClass.getDeclaredField("instance");
+        instanceField.setAccessible(true);
+        final LogHandler originalHandler = (LogHandler) instanceField.get(null);
+        instanceField.set(null, constructor.newInstance(recordingLogger));
+        final Job updateJob;
+        try
         {
-            final LogHandler mockLog = mock(LogHandler.class);
-            logs.when(LogHandler::getInstance).thenReturn(mockLog);
+            final MoreUnitAnnotationModel model = new MoreUnitAnnotationModel(mock(IDocument.class), editor);
+            final Field jobField = MoreUnitAnnotationModel.class.getDeclaredField("updateJob");
+            jobField.setAccessible(true);
+            updateJob = (Job) jobField.get(model);
+            assertNotNull(updateJob);
 
-            new MoreUnitAnnotationModel(mock(IDocument.class), editor);
-
-            verify(mockLog, timeout(15000)).handleExceptionLog(any(Throwable.class));
+            // wait for the job itself: a completed job that did not log means
+            // the expected catch branch was not reached, which must fail loudly
+            assertTrue(updateJob.join(20000, new NullProgressMonitor()), "update job did not complete in time");
         }
+        finally
+        {
+            instanceField.set(null, originalHandler);
+        }
+        assertFalse(loggedErrors.isEmpty(), "expected the job failure to be logged");
     }
 
     @Test

--- a/org.moreunit.test/test/org/moreunit/annotation/MoreUnitAnnotationModelBranchesCoverageTest.java
+++ b/org.moreunit.test/test/org/moreunit/annotation/MoreUnitAnnotationModelBranchesCoverageTest.java
@@ -1,0 +1,390 @@
+package org.moreunit.annotation;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Iterator;
+import java.util.List;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.ISourceRange;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.source.Annotation;
+import org.eclipse.jface.text.source.AnnotationModelEvent;
+import org.eclipse.jface.text.source.IAnnotationModel;
+import org.eclipse.jface.text.source.IAnnotationModelExtension;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.IEditorReference;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.texteditor.IDocumentProvider;
+import org.eclipse.ui.texteditor.ITextEditor;
+import org.junit.jupiter.api.Test;
+import org.moreunit.elements.ClassTypeFacade;
+import org.moreunit.log.LogHandler;
+import org.moreunit.preferences.Preferences;
+import org.moreunit.preferences.TestAnnotationMode;
+import org.moreunit.test.context.Context;
+import org.moreunit.test.context.ContextTestCase;
+import org.moreunit.test.context.configs.SimpleJUnit4Project;
+
+public class MoreUnitAnnotationModelBranchesCoverageTest extends ContextTestCase
+{
+    private ITextEditor editorWithProvider(IDocumentProvider provider)
+    {
+        final ITextEditor editor = mock(ITextEditor.class);
+        when(editor.getDocumentProvider()).thenReturn(provider);
+        return editor;
+    }
+
+    @Test
+    public void should_do_nothing_on_update_when_editor_has_no_document_provider()
+    {
+        final ITextEditor editor = mock(ITextEditor.class);
+        when(editor.getDocumentProvider()).thenReturn(null);
+
+        assertDoesNotThrow(() -> MoreUnitAnnotationModel.updateAnnotations(editor));
+    }
+
+    @Test
+    public void should_do_nothing_on_update_when_annotation_model_is_not_extensible()
+    {
+        final IDocumentProvider provider = mock(IDocumentProvider.class);
+        when(provider.getAnnotationModel(any())).thenReturn(mock(IAnnotationModel.class));
+
+        assertDoesNotThrow(() -> MoreUnitAnnotationModel.updateAnnotations(editorWithProvider(provider)));
+        verify(provider).getAnnotationModel(any());
+    }
+
+    @Test
+    public void should_do_nothing_on_update_when_no_model_is_attached()
+    {
+        final IAnnotationModelExtension model = mock(IAnnotationModelExtension.class, withSettings().extraInterfaces(IAnnotationModel.class));
+        when(model.getAnnotationModel(anyString())).thenReturn(null);
+        final IDocumentProvider provider = mock(IDocumentProvider.class);
+        when(provider.getAnnotationModel(any())).thenReturn((IAnnotationModel) model);
+
+        assertDoesNotThrow(() -> MoreUnitAnnotationModel.updateAnnotations(editorWithProvider(provider)));
+        verify(model).getAnnotationModel(anyString());
+    }
+
+    @Test
+    public void should_do_nothing_on_attach_when_editor_has_no_document_provider()
+    {
+        final ITextEditor editor = mock(ITextEditor.class);
+        when(editor.getDocumentProvider()).thenReturn(null);
+
+        assertDoesNotThrow(() -> MoreUnitAnnotationModel.attach(editor));
+    }
+
+    @Test
+    public void should_do_nothing_on_attach_when_annotation_model_is_not_extensible()
+    {
+        final IDocumentProvider provider = mock(IDocumentProvider.class);
+        when(provider.getAnnotationModel(any())).thenReturn(mock(IAnnotationModel.class));
+
+        assertDoesNotThrow(() -> MoreUnitAnnotationModel.attach(editorWithProvider(provider)));
+        verify(provider).getAnnotationModel(any());
+    }
+
+    @Test
+    public void should_do_nothing_on_detach_when_editor_has_no_document_provider()
+    {
+        final ITextEditor editor = mock(ITextEditor.class);
+        when(editor.getDocumentProvider()).thenReturn(null);
+
+        assertDoesNotThrow(() -> MoreUnitAnnotationModel.detach(editor));
+    }
+
+    @Test
+    public void should_do_nothing_on_detach_when_annotation_model_is_not_extensible()
+    {
+        final IDocumentProvider provider = mock(IDocumentProvider.class);
+        when(provider.getAnnotationModel(any())).thenReturn(mock(IAnnotationModel.class));
+
+        assertDoesNotThrow(() -> MoreUnitAnnotationModel.detach(editorWithProvider(provider)));
+        verify(provider).getAnnotationModel(any());
+    }
+
+    @Test
+    public void should_do_nothing_on_detach_when_no_model_is_attached()
+    {
+        final IAnnotationModelExtension model = mock(IAnnotationModelExtension.class, withSettings().extraInterfaces(IAnnotationModel.class));
+        when(model.removeAnnotationModel(anyString())).thenReturn(null);
+        final IDocumentProvider provider = mock(IDocumentProvider.class);
+        when(provider.getAnnotationModel(any())).thenReturn((IAnnotationModel) model);
+
+        assertDoesNotThrow(() -> MoreUnitAnnotationModel.detach(editorWithProvider(provider)));
+        verify(model).removeAnnotationModel(anyString());
+    }
+
+    @Test
+    public void should_visit_all_open_editors_when_attaching_for_all_open_editors()
+    {
+        final ITextEditor textEditor = mock(ITextEditor.class);
+        when(textEditor.getDocumentProvider()).thenReturn(null);
+        final IEditorReference textEditorRef = mock(IEditorReference.class);
+        when(textEditorRef.getPart(false)).thenReturn(textEditor);
+        final IEditorReference otherPartRef = mock(IEditorReference.class);
+        when(otherPartRef.getPart(false)).thenReturn(mock(IWorkbenchPart.class));
+
+        final IWorkbenchPage page = mock(IWorkbenchPage.class);
+        when(page.getEditorReferences()).thenReturn(new IEditorReference[] { textEditorRef, otherPartRef });
+        final IWorkbenchWindow window = mock(IWorkbenchWindow.class);
+        when(window.getPages()).thenReturn(new IWorkbenchPage[] { page });
+        final IWorkbench workbench = mock(IWorkbench.class);
+        when(workbench.getWorkbenchWindows()).thenReturn(new IWorkbenchWindow[] { window });
+
+        try (var platform = mockStatic(PlatformUI.class))
+        {
+            platform.when(PlatformUI::getWorkbench).thenReturn(workbench);
+
+            assertDoesNotThrow(MoreUnitAnnotationModel::attachForAllOpenEditor);
+            verify(textEditorRef).getPart(false);
+            verify(otherPartRef).getPart(false);
+        }
+    }
+
+    @Test
+    public void should_log_exception_when_update_job_fails()
+    {
+        // given an editor that fails as soon as it is accessed
+        final ITextEditor editor = mock(ITextEditor.class);
+        when(editor.getEditorInput()).thenThrow(new RuntimeException("boom"));
+
+        try (var logs = mockStatic(LogHandler.class))
+        {
+            final LogHandler mockLog = mock(LogHandler.class);
+            logs.when(LogHandler::getInstance).thenReturn(mockLog);
+
+            new MoreUnitAnnotationModel(mock(IDocument.class), editor);
+
+            verify(mockLog, timeout(15000)).handleExceptionLog(any(Throwable.class));
+        }
+    }
+
+    @Test
+    public void should_not_reschedule_update_when_previous_run_was_cancelled() throws Exception
+    {
+        // given a model whose previous update was cancelled
+        final IEditorInput editorInput = mock(IEditorInput.class);
+        when(editorInput.getAdapter(IFile.class)).thenReturn(null);
+        final ITextEditor editor = mock(ITextEditor.class);
+        when(editor.getEditorInput()).thenReturn(editorInput);
+        final MoreUnitAnnotationModel model = new MoreUnitAnnotationModel(mock(IDocument.class), editor);
+
+        final Job cancelledJob = mock(Job.class);
+        when(cancelledJob.getResult()).thenReturn(Status.CANCEL_STATUS);
+        final Field jobField = MoreUnitAnnotationModel.class.getDeclaredField("updateJob");
+        jobField.setAccessible(true);
+        jobField.set(model, cancelledJob);
+
+        // when triggering another update, then no new job is scheduled
+        final Method updateAnnotations = MoreUnitAnnotationModel.class.getDeclaredMethod("updateAnnotations");
+        updateAnnotations.setAccessible(true);
+        assertDoesNotThrow(() -> {
+            try
+            {
+                updateAnnotations.invoke(model);
+            }
+            catch (final ReflectiveOperationException e)
+            {
+                throw new RuntimeException(e);
+            }
+        });
+        verify(cancelledJob, never()).schedule();
+    }
+
+    @Test
+    public void should_stop_annotating_when_monitor_is_cancelled() throws Exception
+    {
+        // given a model and a cancelled monitor
+        final IEditorInput editorInput = mock(IEditorInput.class);
+        when(editorInput.getAdapter(IFile.class)).thenReturn(null);
+        final ITextEditor editor = mock(ITextEditor.class);
+        when(editor.getEditorInput()).thenReturn(editorInput);
+        final MoreUnitAnnotationModel model = new MoreUnitAnnotationModel(mock(IDocument.class), editor);
+
+        final IType type = mock(IType.class);
+        when(type.getElementName()).thenReturn("Foo");
+        when(type.getMethods()).thenReturn(new IMethod[] { mock(IMethod.class) });
+        final IProgressMonitor monitor = mock(IProgressMonitor.class);
+        when(monitor.isCanceled()).thenReturn(true);
+
+        try (var prefs = mockStatic(Preferences.class))
+        {
+            final Preferences.ProjectPreferences view = mock(Preferences.ProjectPreferences.class);
+            prefs.when(() -> Preferences.forProject(any())).thenReturn(view);
+            when(view.getTestAnnotationMode()).thenReturn(TestAnnotationMode.BY_NAME);
+
+            final Method annotate = MoreUnitAnnotationModel.class.getDeclaredMethod("annotateTestedMethods", IType.class, ClassTypeFacade.class, AnnotationModelEvent.class, IProgressMonitor.class);
+            annotate.setAccessible(true);
+            try
+            {
+                annotate.invoke(model, type, mock(ClassTypeFacade.class), mock(AnnotationModelEvent.class), monitor);
+            }
+            catch (final java.lang.reflect.InvocationTargetException e)
+            {
+                throw new AssertionError("unexpected invocation failure", e.getCause());
+            }
+
+            verify(monitor).beginTask(anyString(), org.mockito.ArgumentMatchers.eq(1));
+        }
+    }
+
+    @Test
+    public void should_log_when_annotation_position_cannot_be_added_on_connect() throws Exception
+    {
+        // given a model holding one annotation
+        final IDocument document = mock(IDocument.class);
+        final IEditorInput editorInput = mock(IEditorInput.class);
+        when(editorInput.getAdapter(IFile.class)).thenReturn(null);
+        final ITextEditor editor = mock(ITextEditor.class);
+        when(editor.getEditorInput()).thenReturn(editorInput);
+        final MoreUnitAnnotationModel model = new MoreUnitAnnotationModel(document, editor);
+
+        @SuppressWarnings("unchecked")
+        final List<MoreUnitAnnotation> annotations = (List<MoreUnitAnnotation>) field(model, "annotations");
+        annotations.add(MoreUnitAnnotation.createAnnotationForTestedMethod(mock(ISourceRange.class)));
+
+        org.mockito.Mockito.doThrow(new BadLocationException()).when(document).addPosition(any(Position.class));
+
+        try (var logs = mockStatic(LogHandler.class))
+        {
+            final LogHandler mockLog = mock(LogHandler.class);
+            logs.when(LogHandler::getInstance).thenReturn(mockLog);
+
+            // when
+            model.connect(document);
+
+            // then the failure was logged
+            verify(mockLog).handleExceptionLog(any(BadLocationException.class));
+        }
+    }
+
+    private static Object field(Object target, String fieldName) throws Exception
+    {
+        final Field field = MoreUnitAnnotationModel.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field.get(target);
+    }
+
+    // ------------------------------------------------------------------
+    // Tests running against a real compilation unit and the update job
+    // ------------------------------------------------------------------
+
+    private ITextEditor editorOver(ICompilationUnit compilationUnit)
+    {
+        final IEditorInput editorInput = mock(IEditorInput.class);
+        when(editorInput.getAdapter(IFile.class)).thenReturn((IFile) compilationUnit.getResource());
+        final ITextEditor editor = mock(ITextEditor.class);
+        when(editor.getEditorInput()).thenReturn(editorInput);
+        return editor;
+    }
+
+    private MoreUnitAnnotationModel modelFor(ICompilationUnit compilationUnit) throws Exception
+    {
+        final IDocument document = new org.eclipse.jface.text.Document(compilationUnit.getSource());
+        return new MoreUnitAnnotationModel(document, editorOver(compilationUnit));
+    }
+
+    private void await(Runnable assertion) throws Exception
+    {
+        final Display display = Display.getDefault();
+        final long deadline = System.currentTimeMillis() + 30_000;
+        AssertionError lastFailure = null;
+        while (System.currentTimeMillis() < deadline)
+        {
+            while (display.readAndDispatch())
+            {
+            }
+            try
+            {
+                assertion.run();
+                return;
+            }
+            catch (final AssertionError e)
+            {
+                lastFailure = e;
+            }
+            Thread.sleep(20);
+            display.readAndDispatch();
+        }
+        throw lastFailure != null ? lastFailure : new AssertionError("condition not met in time");
+    }
+
+    private int annotationCount(MoreUnitAnnotationModel model)
+    {
+        int count = 0;
+        for (final Iterator<Annotation> it = model.getAnnotationIterator(); it.hasNext(); it.next())
+        {
+            count++;
+        }
+        return count;
+    }
+
+    @Context(SimpleJUnit4Project.class)
+    @Test
+    public void should_create_tested_annotation_when_test_method_has_other_annotations() throws Exception
+    {
+        final ICompilationUnit cut = context.getCompilationUnit("org.SomeClass");
+        context.getPrimaryTypeHandler("org.SomeClass").addMethod("public int getNumber()", "return 1;");
+        context.getPrimaryTypeHandler("org.SomeClassTest").addMethod("@Deprecated public void getNumber()", "");
+        Preferences.getInstance().setTestAnnotationMode(cut.getJavaProject(), TestAnnotationMode.BY_NAME);
+
+        final MoreUnitAnnotationModel model = modelFor(cut);
+
+        await(() -> assertEquals(1, annotationCount(model)));
+
+        final MoreUnitAnnotation annotation = (MoreUnitAnnotation) model.getAnnotationIterator().next();
+        assertEquals(MoreUnitAnnotation.ANNOTATION_ID, annotation.getType());
+    }
+
+    @Test
+    public void should_keep_existing_model_when_attaching_twice()
+    {
+        // given an editor with a plain annotation model
+        final org.eclipse.jface.text.source.AnnotationModel annotationModel = new org.eclipse.jface.text.source.AnnotationModel();
+        final IDocumentProvider provider = mock(IDocumentProvider.class);
+        when(provider.getAnnotationModel(any())).thenReturn(annotationModel);
+        when(provider.getDocument(any())).thenReturn(new org.eclipse.jface.text.Document(""));
+        final IEditorInput editorInput = mock(IEditorInput.class);
+        when(editorInput.getAdapter(IFile.class)).thenReturn(null);
+        final ITextEditor editor = mock(ITextEditor.class);
+        when(editor.getEditorInput()).thenReturn(editorInput);
+        when(editor.getDocumentProvider()).thenReturn(provider);
+
+        // when attaching twice, then the same model is kept
+        MoreUnitAnnotationModel.attach(editor);
+        final Object attached = annotationModel.getAnnotationModel("org.moreunit.model_key");
+        assertNotNull(attached);
+
+        MoreUnitAnnotationModel.attach(editor);
+        assertSame(attached, annotationModel.getAnnotationModel("org.moreunit.model_key"));
+    }
+}

--- a/org.moreunit.test/test/org/moreunit/elements/EditorPartFacadeBranchesCoverageTest.java
+++ b/org.moreunit.test/test/org/moreunit/elements/EditorPartFacadeBranchesCoverageTest.java
@@ -1,0 +1,140 @@
+package org.moreunit.elements;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaCore;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jface.text.ITextSelection;
+import org.eclipse.jface.viewers.ISelectionProvider;
+import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IWorkbenchPartSite;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+import org.moreunit.log.LogHandler;
+
+public class EditorPartFacadeBranchesCoverageTest
+{
+    private IEditorPart mockEditorPartShowing(IFile file)
+    {
+        final IEditorInput editorInput = mock(IEditorInput.class);
+        when(editorInput.getAdapter(IFile.class)).thenReturn(file);
+
+        final IEditorPart editorPart = mock(IEditorPart.class);
+        when(editorPart.getEditorInput()).thenReturn(editorInput);
+        return editorPart;
+    }
+
+    private EditorPartFacade facadeWithCursorAt(IEditorPart editorPart, int offset)
+    {
+        final IWorkbenchPartSite site = mock(IWorkbenchPartSite.class);
+        final ISelectionProvider selectionProvider = mock(ISelectionProvider.class);
+        final ITextSelection selection = mock(ITextSelection.class);
+        when(selection.getOffset()).thenReturn(offset);
+        when(selectionProvider.getSelection()).thenReturn(selection);
+        when(site.getSelectionProvider()).thenReturn(selectionProvider);
+        when(editorPart.getSite()).thenReturn(site);
+
+        return new EditorPartFacade(editorPart);
+    }
+
+    @Test
+    public void should_return_null_and_log_when_element_lookup_fails() throws Exception
+    {
+        // given a compilation unit that fails on element lookup
+        final ICompilationUnit compilationUnit = mock(ICompilationUnit.class);
+        when(compilationUnit.getElementAt(anyInt())).thenThrow(new JavaModelException(new RuntimeException("boom"), 1));
+
+        try (var javaCore = mockStatic(JavaCore.class, Answers.CALLS_REAL_METHODS);
+             var logs = mockStatic(LogHandler.class))
+        {
+            javaCore.when(() -> JavaCore.createCompilationUnitFrom(any(IFile.class))).thenReturn(compilationUnit);
+            final LogHandler mockLog = mock(LogHandler.class);
+            logs.when(LogHandler::getInstance).thenReturn(mockLog);
+
+            final EditorPartFacade facade = facadeWithCursorAt(mockEditorPartShowing(mock(IFile.class)), 5);
+
+            // when
+            final IMethod result = facade.getMethodUnderCursorPosition();
+
+            // then
+            assertNull(result);
+            verify(mockLog).handleExceptionLog(any(JavaModelException.class));
+        }
+    }
+
+    @Test
+    public void should_log_when_surrounding_method_lookup_fails() throws Exception
+    {
+        // given a compilation unit that fails on element lookup
+        final ICompilationUnit compilationUnit = mock(ICompilationUnit.class);
+        when(compilationUnit.getElementAt(anyInt())).thenThrow(new JavaModelException(new RuntimeException("boom"), 1));
+
+        try (var javaCore = mockStatic(JavaCore.class, Answers.CALLS_REAL_METHODS);
+             var logs = mockStatic(LogHandler.class))
+        {
+            javaCore.when(() -> JavaCore.createCompilationUnitFrom(any(IFile.class))).thenReturn(compilationUnit);
+            final LogHandler mockLog = mock(LogHandler.class);
+            logs.when(LogHandler::getInstance).thenReturn(mockLog);
+
+            final EditorPartFacade facade = facadeWithCursorAt(mockEditorPartShowing(mock(IFile.class)), 5);
+
+            // when
+            final IMethod result = facade.getFirstNonAnonymousMethodSurroundingCursorPosition();
+
+            // then
+            assertNull(result);
+            verify(mockLog).handleExceptionLog(any(JavaModelException.class));
+        }
+    }
+
+    @Test
+    public void should_return_null_for_first_non_anonymous_method_when_no_compilation_unit()
+    {
+        // given an editor without any file
+        final EditorPartFacade facade = facadeWithCursorAt(mockEditorPartShowing(null), 0);
+
+        // when, then
+        assertNull(facade.getFirstNonAnonymousMethodSurroundingCursorPosition());
+    }
+
+    @Test
+    public void should_return_enclosing_method_when_cursor_is_on_anonymous_type() throws Exception
+    {
+        // given a cursor located on an anonymous type
+        final IMethod enclosingMethod = mock(IMethod.class);
+        final IType anonymousType = mock(IType.class);
+        when(anonymousType.isAnonymous()).thenReturn(true);
+        when(anonymousType.getParent()).thenReturn(enclosingMethod);
+        final IType declaringType = mock(IType.class);
+        when(declaringType.isAnonymous()).thenReturn(false);
+        when(enclosingMethod.getParent()).thenReturn(declaringType);
+
+        final ICompilationUnit compilationUnit = mock(ICompilationUnit.class);
+        when(compilationUnit.getElementAt(7)).thenReturn(anonymousType);
+
+        try (var javaCore = mockStatic(JavaCore.class, Answers.CALLS_REAL_METHODS))
+        {
+            javaCore.when(() -> JavaCore.createCompilationUnitFrom(any(IFile.class))).thenReturn(compilationUnit);
+
+            final EditorPartFacade facade = facadeWithCursorAt(mockEditorPartShowing(mock(IFile.class)), 7);
+
+            // when
+            final IMethod result = facade.getFirstNonAnonymousMethodSurroundingCursorPosition();
+
+            // then the enclosing method is returned
+            assertSame(enclosingMethod, result);
+        }
+    }
+}

--- a/org.moreunit.test/test/org/moreunit/elements/TestmethodCreatorBranchesCoverageTest.java
+++ b/org.moreunit.test/test/org/moreunit/elements/TestmethodCreatorBranchesCoverageTest.java
@@ -297,8 +297,8 @@ public class TestmethodCreatorBranchesCoverageTest
             final LogHandler mockLog = mock(LogHandler.class);
             logs.when(LogHandler::getInstance).thenReturn(mockLog);
 
-            // when
-            final IMethod result = creator.findTestMethod("anything");
+            // when (protected method across bundles: call reflectively)
+            final IMethod result = (IMethod) callPrivate(creator, "findTestMethod", new Class< ? >[] { String.class }, new Object[] { "anything" });
 
             // then
             assertNull(result);

--- a/org.moreunit.test/test/org/moreunit/elements/TestmethodCreatorBranchesCoverageTest.java
+++ b/org.moreunit.test/test/org/moreunit/elements/TestmethodCreatorBranchesCoverageTest.java
@@ -1,0 +1,308 @@
+package org.moreunit.elements;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.moreunit.preferences.PreferenceConstants.TEST_TYPE_VALUE_JUNIT_3;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.eclipse.jdt.core.ICompilationUnit;
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
+import org.eclipse.jdt.core.formatter.CodeFormatter;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.text.edits.MalformedTreeException;
+import org.eclipse.text.edits.TextEdit;
+import org.junit.jupiter.api.Test;
+import org.moreunit.core.util.StringConstants;
+import org.moreunit.elements.TestmethodCreator.TestMethodCreationSettings;
+import org.moreunit.log.LogHandler;
+
+public class TestmethodCreatorBranchesCoverageTest
+{
+    private static TestmethodCreator creatorOverMocks(boolean generateComments) throws Exception
+    {
+        return creatorFor(mock(ICompilationUnit.class), generateComments);
+    }
+
+    private static TestmethodCreator creatorFor(ICompilationUnit compilationUnit, boolean generateComments) throws Exception
+    {
+        return new TestmethodCreator(new TestMethodCreationSettings().compilationUnit(compilationUnit).testType(TEST_TYPE_VALUE_JUNIT_3).generateComments(generateComments).defaultTestMethodContent("// test"));
+    }
+
+    private static IType typeThrowingOnMethods() throws Exception
+    {
+        final IType type = mock(IType.class);
+        when(type.getMethods()).thenThrow(new JavaModelException(new RuntimeException("boom"), 1));
+        return type;
+    }
+
+    private static void setPrivateField(Object target, String fieldName, Object value) throws Exception
+    {
+        final Field field = TestmethodCreator.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    private static Object callPrivate(Object target, String methodName, Class< ? >[] parameterTypes, Object[] args) throws Exception
+    {
+        final Method method = TestmethodCreator.class.getDeclaredMethod(methodName, parameterTypes);
+        method.setAccessible(true);
+        try
+        {
+            return method.invoke(target, args);
+        }
+        catch (final InvocationTargetException e)
+        {
+            throw new AssertionError("unexpected invocation failure", e.getCause());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<IMethod> callGetOverloadedMethods(TestmethodCreator creator) throws Exception
+    {
+        return (List<IMethod>) callPrivate(creator, "getOverloadedMethods", new Class< ? >[0], new Object[0]);
+    }
+
+    private static void giveSilentFormatter(TestmethodCreator creator) throws Exception
+    {
+        final CodeFormatter formatter = mock(CodeFormatter.class);
+        final TextEdit edit = mock(TextEdit.class);
+        when(formatter.format(anyInt(), anyString(), anyInt(), anyInt(), anyInt(), anyString())).thenReturn(edit);
+        setPrivateField(creator, "testFormatter", formatter);
+    }
+
+    @Test
+    public void should_return_empty_overloaded_list_when_methods_cannot_be_read() throws Exception
+    {
+        // given a compilation unit whose methods cannot be read
+        final ICompilationUnit compilationUnit = mock(ICompilationUnit.class);
+        final IType unreadableType = typeThrowingOnMethods();
+        when(compilationUnit.findPrimaryType()).thenReturn(unreadableType);
+        final TestmethodCreator creator = creatorFor(compilationUnit, false);
+
+        // when
+        final List<IMethod> result = callGetOverloadedMethods(creator);
+
+        // then no overloaded method is reported
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void should_return_empty_comment_when_javadoc_cannot_be_read() throws Exception
+    {
+        // given comments are requested but the javadoc cannot be read
+        final TestmethodCreator creator = creatorOverMocks(true);
+        final IMethod method = mock(IMethod.class);
+        when(method.getJavadocRange()).thenThrow(new JavaModelException(new RuntimeException("boom"), 1));
+
+        // when
+        final String result = (String) callPrivate(creator, "getComments", new Class< ? >[] { IMethod.class }, new Object[] { method });
+
+        // then
+        assertEquals("", result);
+    }
+
+    @Test
+    public void should_return_empty_comment_when_comments_are_not_requested() throws Exception
+    {
+        final TestmethodCreator creator = creatorOverMocks(false);
+
+        final String result = (String) callPrivate(creator, "getComments", new Class< ? >[] { IMethod.class }, new Object[] { mock(IMethod.class) });
+
+        assertEquals("", result);
+    }
+
+    @Test
+    public void should_return_null_sibling_when_methods_cannot_be_read() throws Exception
+    {
+        // given a test case whose methods cannot be read
+        final TestmethodCreator creator = creatorOverMocks(false);
+        final ICompilationUnit testCaseUnit = mock(ICompilationUnit.class);
+        final IType unreadableTestCaseType = typeThrowingOnMethods();
+        when(testCaseUnit.findPrimaryType()).thenReturn(unreadableTestCaseType);
+        setPrivateField(creator, "testCaseCompilationUnit", testCaseUnit);
+
+        try (var logs = mockStatic(LogHandler.class))
+        {
+            final LogHandler mockLog = mock(LogHandler.class);
+            logs.when(LogHandler::getInstance).thenReturn(mockLog);
+
+            // when
+            final Object result = callPrivate(creator, "getSiblingForInsert", new Class< ? >[] { IMethod.class }, new Object[] { mock(IMethod.class) });
+
+            // then
+            assertNull(result);
+            verify(mockLog).handleExceptionLog(any(JavaModelException.class));
+        }
+    }
+
+    @Test
+    public void should_use_default_line_separator_when_it_cannot_be_read() throws Exception
+    {
+        // given a test case whose line separator cannot be read
+        final TestmethodCreator creator = creatorOverMocks(false);
+        final ICompilationUnit testCaseUnit = mock(ICompilationUnit.class);
+        when(testCaseUnit.findRecommendedLineSeparator()).thenThrow(new JavaModelException(new RuntimeException("boom"), 1));
+        setPrivateField(creator, "testCaseCompilationUnit", testCaseUnit);
+
+        try (var logs = mockStatic(LogHandler.class))
+        {
+            final LogHandler mockLog = mock(LogHandler.class);
+            logs.when(LogHandler::getInstance).thenReturn(mockLog);
+
+            // when
+            final String result = (String) callPrivate(creator, "findRecommendedLineSeparator", new Class< ? >[0], new Object[0]);
+
+            // then the default separator is used
+            assertEquals(StringConstants.NEWLINE, result);
+            verify(mockLog).handleExceptionLog(any(JavaModelException.class));
+        }
+    }
+
+    @Test
+    public void should_return_null_when_method_already_exists() throws Exception
+    {
+        // given a test case that already contains the method
+        final TestmethodCreator creator = creatorOverMocks(false);
+        final IMethod existing = mock(IMethod.class);
+        when(existing.getElementName()).thenReturn("existing");
+        final IType testCaseType = mock(IType.class);
+        when(testCaseType.getMethods()).thenReturn(new IMethod[] { existing });
+        final ICompilationUnit testCaseUnit = mock(ICompilationUnit.class);
+        when(testCaseUnit.findPrimaryType()).thenReturn(testCaseType);
+        setPrivateField(creator, "testCaseCompilationUnit", testCaseUnit);
+
+        // when
+        final Object result = callPrivate(creator, "createMethod", new Class< ? >[] { String.class, String.class, IMethod.class }, new Object[] { "existing", "public void existing() {}", null });
+
+        // then nothing is created
+        assertNull(result);
+    }
+
+    @Test
+    public void should_log_when_test_method_creation_fails_with_java_model_exception() throws Exception
+    {
+        // given a test case that fails on method creation
+        final TestmethodCreator creator = creatorOverMocks(false);
+        final IType testCaseType = mock(IType.class);
+        when(testCaseType.getMethods()).thenReturn(new IMethod[0]);
+        when(testCaseType.createMethod(anyString(), any(), anyBoolean(), any())).thenThrow(new JavaModelException(new RuntimeException("boom"), 1));
+        final ICompilationUnit testCaseUnit = mock(ICompilationUnit.class);
+        when(testCaseUnit.findPrimaryType()).thenReturn(testCaseType);
+        setPrivateField(creator, "testCaseCompilationUnit", testCaseUnit);
+        giveSilentFormatter(creator);
+
+        try (var logs = mockStatic(LogHandler.class))
+        {
+            final LogHandler mockLog = mock(LogHandler.class);
+            logs.when(LogHandler::getInstance).thenReturn(mockLog);
+
+            // when
+            final Object result = callPrivate(creator, "createMethod", new Class< ? >[] { String.class, String.class, IMethod.class }, new Object[] { "fresh", "public void fresh() {}", null });
+
+            // then
+            assertNull(result);
+            verify(mockLog).handleExceptionLog(any(JavaModelException.class));
+        }
+    }
+
+    @Test
+    public void should_log_when_test_method_creation_fails_with_malformed_tree() throws Exception
+    {
+        // given a test case that fails on method creation
+        final TestmethodCreator creator = creatorOverMocks(false);
+        final IType testCaseType = mock(IType.class);
+        when(testCaseType.getMethods()).thenReturn(new IMethod[0]);
+        when(testCaseType.createMethod(anyString(), any(), anyBoolean(), any())).thenThrow(mock(MalformedTreeException.class));
+        final ICompilationUnit testCaseUnit = mock(ICompilationUnit.class);
+        when(testCaseUnit.findPrimaryType()).thenReturn(testCaseType);
+        setPrivateField(creator, "testCaseCompilationUnit", testCaseUnit);
+        giveSilentFormatter(creator);
+
+        try (var logs = mockStatic(LogHandler.class))
+        {
+            final LogHandler mockLog = mock(LogHandler.class);
+            logs.when(LogHandler::getInstance).thenReturn(mockLog);
+
+            // when
+            final Object result = callPrivate(creator, "createMethod", new Class< ? >[] { String.class, String.class, IMethod.class }, new Object[] { "fresh", "public void fresh() {}", null });
+
+            // then
+            assertNull(result);
+            verify(mockLog).handleExceptionLog(any(MalformedTreeException.class));
+        }
+    }
+
+    @Test
+    public void should_log_when_test_method_creation_fails_with_bad_location() throws Exception
+    {
+        // given a formatter whose edit cannot be applied
+        final TestmethodCreator creator = creatorOverMocks(false);
+        final IType testCaseType = mock(IType.class);
+        when(testCaseType.getMethods()).thenReturn(new IMethod[0]);
+        final ICompilationUnit testCaseUnit = mock(ICompilationUnit.class);
+        when(testCaseUnit.findPrimaryType()).thenReturn(testCaseType);
+        setPrivateField(creator, "testCaseCompilationUnit", testCaseUnit);
+
+        final CodeFormatter formatter = mock(CodeFormatter.class);
+        final TextEdit edit = mock(TextEdit.class);
+        doThrow(new BadLocationException()).when(edit).apply(any(IDocument.class));
+        when(formatter.format(anyInt(), anyString(), anyInt(), anyInt(), anyInt(), anyString())).thenReturn(edit);
+        setPrivateField(creator, "testFormatter", formatter);
+
+        try (var logs = mockStatic(LogHandler.class))
+        {
+            final LogHandler mockLog = mock(LogHandler.class);
+            logs.when(LogHandler::getInstance).thenReturn(mockLog);
+
+            // when
+            final Object result = callPrivate(creator, "createMethod", new Class< ? >[] { String.class, String.class, IMethod.class }, new Object[] { "fresh", "public void fresh() {}", null });
+
+            // then
+            assertNull(result);
+            verify(mockLog).handleExceptionLog(any(BadLocationException.class));
+        }
+    }
+
+    @Test
+    public void should_return_null_when_test_method_lookup_fails() throws Exception
+    {
+        // given a test case whose methods cannot be read
+        final TestmethodCreator creator = creatorOverMocks(false);
+        final ICompilationUnit testCaseUnit = mock(ICompilationUnit.class);
+        final IType unreadableTestCaseType = typeThrowingOnMethods();
+        when(testCaseUnit.findPrimaryType()).thenReturn(unreadableTestCaseType);
+        setPrivateField(creator, "testCaseCompilationUnit", testCaseUnit);
+
+        try (var logs = mockStatic(LogHandler.class))
+        {
+            final LogHandler mockLog = mock(LogHandler.class);
+            logs.when(LogHandler::getInstance).thenReturn(mockLog);
+
+            // when
+            final IMethod result = creator.findTestMethod("anything");
+
+            // then
+            assertNull(result);
+            verify(mockLog).handleExceptionLog(any(JavaModelException.class));
+        }
+    }
+}

--- a/org.moreunit.test/test/org/moreunit/elements/TypeFacadeBranchesCoverageTest.java
+++ b/org.moreunit.test/test/org/moreunit/elements/TypeFacadeBranchesCoverageTest.java
@@ -1,0 +1,149 @@
+package org.moreunit.elements;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collection;
+
+import org.eclipse.jdt.core.IMember;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.core.JavaModelException;
+import org.junit.jupiter.api.Test;
+import org.moreunit.elements.CorrespondingMemberRequest.MemberType;
+import org.moreunit.test.context.ContextTestCase;
+import org.moreunit.test.context.Preferences;
+import org.moreunit.test.context.Project;
+
+public class TypeFacadeBranchesCoverageTest extends ContextTestCase
+{
+    @Project(mainCls = "Hello")
+    @Preferences(testClassNameTemplate = "${srcFile}Test")
+    @Test
+    public void should_return_null_when_no_corresponding_member_exists_and_creation_is_not_requested() throws JavaModelException
+    {
+        // given a class without any corresponding test case
+        final ClassTypeFacade facade = new ClassTypeFacade(context.getCompilationUnit("Hello"));
+        final CorrespondingMemberRequest request = CorrespondingMemberRequest.newCorrespondingMemberRequest() //
+                .withExpectedResultType(MemberType.TYPE_OR_METHOD) //
+                .build();
+
+        // when
+        final IMember result = facade.getOneCorrespondingMember(request);
+
+        // then
+        assertNull(result);
+    }
+
+    @Project(mainCls = "com:Foo", testCls = "com:FooTest", mainSrcFolder = "src", testSrcFolder = "test")
+    @Preferences(testClassNameTemplate = "${srcFile}Test", testSrcFolder = "test")
+    @Test
+    public void should_return_matching_class_when_single_perfect_match_exists() throws JavaModelException
+    {
+        // given a class with exactly one corresponding test case
+        final ClassTypeFacade facade = new ClassTypeFacade(context.getCompilationUnit("com.Foo"));
+        final CorrespondingMemberRequest request = CorrespondingMemberRequest.newCorrespondingMemberRequest() //
+                .withExpectedResultType(MemberType.TYPE_OR_METHOD) //
+                .build();
+
+        // when
+        final IMember result = facade.getOneCorrespondingMember(request);
+
+        // then the test case is returned without any dialog
+        assertEquals(context.getPrimaryTypeHandler("com.FooTest").get(), result);
+    }
+
+    @Project(mainCls = "Hello")
+    @Preferences(testClassNameTemplate = "${srcFile}Test")
+    @Test
+    public void should_build_choice_action_for_multiple_perfect_matches() throws Exception
+    {
+        final ClassTypeFacade facade = new ClassTypeFacade(context.getCompilationUnit("Hello"));
+        final CorrespondingMemberRequest request = mock(CorrespondingMemberRequest.class);
+        when(request.shouldReturn(MemberType.TYPE_OR_METHOD)).thenReturn(false);
+
+        final Object action = callGetPerfectCorrespondingMember(facade, request, asList(mock(IType.class), mock(IType.class)));
+
+        assertNotNull(action);
+    }
+
+    @Project(mainCls = "Hello")
+    @Preferences(testClassNameTemplate = "${srcFile}Test")
+    @Test
+    public void should_build_wizard_action_when_creation_is_requested_without_match() throws Exception
+    {
+        final ClassTypeFacade facade = new ClassTypeFacade(context.getCompilationUnit("Hello"));
+        final CorrespondingMemberRequest request = mock(CorrespondingMemberRequest.class);
+        when(request.shouldReturn(MemberType.TYPE_OR_METHOD)).thenReturn(false);
+        when(request.shouldCreateClassIfNoResult()).thenReturn(true);
+
+        final Object action = callGetPerfectCorrespondingMember(facade, request, emptyList());
+
+        assertNotNull(action);
+    }
+
+    @Project(mainCls = "Hello")
+    @Preferences(testClassNameTemplate = "${srcFile}Test")
+    @Test
+    public void should_build_null_action_without_match_and_without_creation() throws Exception
+    {
+        final ClassTypeFacade facade = new ClassTypeFacade(context.getCompilationUnit("Hello"));
+        final CorrespondingMemberRequest request = mock(CorrespondingMemberRequest.class);
+        when(request.shouldReturn(MemberType.TYPE_OR_METHOD)).thenReturn(false);
+        when(request.shouldCreateClassIfNoResult()).thenReturn(false);
+
+        final Object action = callGetPerfectCorrespondingMember(facade, request, emptyList());
+
+        assertNull(action);
+    }
+
+    @Project(mainCls = "Hello")
+    @Preferences(testClassNameTemplate = "${srcFile}Test")
+    @Test
+    public void should_build_likely_class_actions_without_opening_any_dialog() throws Exception
+    {
+        final ClassTypeFacade facade = new ClassTypeFacade(context.getCompilationUnit("Hello"));
+
+        final CorrespondingMemberRequest withCreation = mock(CorrespondingMemberRequest.class);
+        when(withCreation.shouldCreateClassIfNoResult()).thenReturn(true);
+        assertNotNull(callGetLikelyCorrespondingClass(facade, withCreation));
+
+        final CorrespondingMemberRequest withoutCreation = mock(CorrespondingMemberRequest.class);
+        when(withoutCreation.shouldCreateClassIfNoResult()).thenReturn(false);
+        assertNull(callGetLikelyCorrespondingClass(facade, withoutCreation));
+    }
+
+    private static Object callGetPerfectCorrespondingMember(TypeFacade facade, CorrespondingMemberRequest request, Collection<IType> classes) throws Exception
+    {
+        final Method method = TypeFacade.class.getDeclaredMethod("getPerfectCorrespondingMember", CorrespondingMemberRequest.class, Collection.class);
+        method.setAccessible(true);
+        try
+        {
+            return method.invoke(facade, request, classes);
+        }
+        catch (final InvocationTargetException e)
+        {
+            throw new AssertionError("unexpected invocation failure", e.getCause());
+        }
+    }
+
+    private static Object callGetLikelyCorrespondingClass(TypeFacade facade, CorrespondingMemberRequest request) throws Exception
+    {
+        final Method method = TypeFacade.class.getDeclaredMethod("getLikelyCorrespondingClass", CorrespondingMemberRequest.class);
+        method.setAccessible(true);
+        try
+        {
+            return method.invoke(facade, request);
+        }
+        catch (final InvocationTargetException e)
+        {
+            throw new AssertionError("unexpected invocation failure", e.getCause());
+        }
+    }
+}

--- a/org.moreunit.test/test/org/moreunit/handler/RunTestsActionExecutorTest.java
+++ b/org.moreunit.test/test/org/moreunit/handler/RunTestsActionExecutorTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -30,6 +31,7 @@ import org.eclipse.jdt.core.IMember;
 import org.eclipse.jdt.core.IMethod;
 import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.ISourceRange;
+import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jface.text.TextSelection;
 import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.swt.widgets.Display;
@@ -37,6 +39,10 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPartSite;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.part.FileEditorInput;
+import org.eclipse.ui.texteditor.ITextEditor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.moreunit.launch.TestLauncher;
@@ -71,6 +77,8 @@ public class RunTestsActionExecutorTest extends ContextTestCase
         }).when(testLauncher).launch(anyString(), anyCollection(), anyString());
 
         setPrivateField("testLauncher", testLauncher);
+        // some tests replace the detector with a mock: always restore the default here
+        setPrivateField("featureDetector", new FeatureDetector());
     }
 
     private void setPrivateField(String fieldName, Object value) throws Exception
@@ -340,5 +348,201 @@ public class RunTestsActionExecutorTest extends ContextTestCase
                 .map(e -> ((IMethod) e).getDeclaringType().getElementName()) //
                 .collect(java.util.stream.Collectors.toSet());
         assertEquals(new java.util.HashSet<>(java.util.Arrays.asList("FooAbstractTestImpl", "FooAbstractTestImpl2")), declaringTypes);
+    }
+
+    @Test
+    public void executeRunTestAction_should_launch_selected_type_itself_when_no_test_case_exists() throws Exception
+    {
+        context.getProjectHandler().getMainSrcFolderHandler().createClass("com.Orphan");
+
+        RunTestsActionExecutor.getInstance().executeRunTestAction(context.getCompilationUnit("com.Orphan"), ILaunchManager.RUN_MODE);
+
+        awaitLaunch();
+        assertEquals(Arrays.asList("Orphan"), launchedElementNames());
+    }
+
+    @Test
+    public void executeRunTestAction_should_save_dirty_editor_before_running_tests() throws Exception
+    {
+        final IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
+        final IFile file = (IFile) context.getCompilationUnit("com.Foo").getResource();
+        final IEditorPart editor = page.openEditor(new FileEditorInput(file), "org.eclipse.ui.DefaultTextEditor", true);
+        try
+        {
+            assertTrue(editor instanceof ITextEditor);
+            final ITextEditor textEditor = (ITextEditor) editor;
+            textEditor.getDocumentProvider().getDocument(editor.getEditorInput()).set("package com;\npublic class Foo {\n}\n// dirty\n");
+            assertTrue(editor.isDirty());
+
+            RunTestsActionExecutor.getInstance().executeRunTestAction(context.getCompilationUnit("com.Foo"), ILaunchManager.RUN_MODE);
+
+            awaitLaunch();
+            assertFalse(editor.isDirty());
+            assertEquals(Arrays.asList("FooTest"), launchedElementNames());
+        }
+        finally
+        {
+            page.closeAllEditors(false);
+        }
+    }
+
+    @Test
+    public void executeRunTestsOfSelectedMemberAction_should_launch_test_case_when_cursor_is_outside_any_method() throws Exception
+    {
+        final IEditorPart editorPart = editorOver(context.getCompilationUnit("com.Foo"), new org.eclipse.jdt.core.SourceRange(0, 0));
+        RunTestsActionExecutor.getInstance().executeRunTestsOfSelectedMemberAction(editorPart, ILaunchManager.RUN_MODE);
+
+        awaitLaunch();
+        assertEquals(Arrays.asList("FooTest"), launchedElementNames());
+    }
+
+    @Test
+    public void executeRunTestsOfSelectedMemberAction_should_launch_class_under_test_when_no_corresponding_test_method_is_found() throws Exception
+    {
+        final IMethod bar = context.getPrimaryTypeHandler("com.Foo").addMethod("public int bar()", "return 1;").get();
+
+        final IEditorPart editorPart = editorOver(context.getCompilationUnit("com.Foo"), bar.getNameRange());
+        RunTestsActionExecutor.getInstance().executeRunTestsOfSelectedMemberAction(editorPart, ILaunchManager.RUN_MODE);
+
+        awaitLaunch();
+        assertEquals(Arrays.asList("Foo"), launchedElementNames());
+    }
+
+    @Test
+    public void executeRunTestsOfSelectedMemberAction_should_use_single_corresponding_member_when_test_selection_run_is_not_supported() throws Exception
+    {
+        final FeatureDetector featureDetector = mock(FeatureDetector.class);
+        when(featureDetector.isTestSelectionRunSupported(any())).thenReturn(false);
+        setPrivateField("featureDetector", featureDetector);
+
+        context.getPrimaryTypeHandler("com.Foo").addMethod("public int foo()", "return 0;");
+        context.getPrimaryTypeHandler("com.FooTest").addMethod("public void foo()", "");
+        final IMethod foo = context.getPrimaryTypeHandler("com.Foo").get().getMethods()[0];
+
+        final IEditorPart editorPart = editorOver(context.getCompilationUnit("com.Foo"), foo.getNameRange());
+        RunTestsActionExecutor.getInstance().executeRunTestsOfSelectedMemberAction(editorPart, ILaunchManager.RUN_MODE);
+
+        awaitLaunch();
+        assertEquals(Arrays.asList("foo"), launchedElementNames());
+    }
+
+    @Test
+    @Preferences(testClassNameTemplate = "${srcFile}*Test", testSrcFolder = "test")
+    public void executeRunTestsOfSelectedMemberAction_should_keep_abstract_test_method_without_concrete_subclass() throws Exception
+    {
+        TypeHandlerAccess.createAbstractTest(context, "com.FooAbstractTest");
+        context.getPrimaryTypeHandler("com.FooAbstractTest").addMethod("@Test\npublic void testFoo()", "");
+
+        final IMethod abstractTestMethod = context.getPrimaryTypeHandler("com.FooAbstractTest").get().getMethods()[0];
+        final IEditorPart editorPart = editorOver(context.getCompilationUnit("com.FooAbstractTest"), abstractTestMethod.getNameRange());
+        RunTestsActionExecutor.getInstance().executeRunTestsOfSelectedMemberAction(editorPart, ILaunchManager.RUN_MODE);
+
+        awaitLaunch();
+        assertEquals(Arrays.asList("testFoo"), launchedElementNames());
+        final IJavaElement launched = launchedMembers.get().iterator().next();
+        assertEquals("FooAbstractTest", ((IMethod) launched).getDeclaringType().getElementName());
+    }
+
+    @Test
+    @Preferences(testClassNameTemplate = "${srcFile}*Test", testSrcFolder = "test")
+    public void executeRunTestsOfSelectedMemberAction_should_replace_abstract_test_type_by_single_concrete_subclass() throws Exception
+    {
+        TypeHandlerAccess.createAbstractTest(context, "com.FooAbstractTest");
+        TypeHandlerAccess.createSubclass(context, "com.FooAbstractTest", "com.FooAbstractTestImpl");
+
+        final IEditorPart editorPart = editorOver(context.getCompilationUnit("com.FooAbstractTest"), new org.eclipse.jdt.core.SourceRange(0, 0));
+        RunTestsActionExecutor.getInstance().executeRunTestsOfSelectedMemberAction(editorPart, ILaunchManager.RUN_MODE);
+
+        awaitLaunch();
+        assertEquals(Arrays.asList("FooAbstractTestImpl"), launchedElementNames());
+    }
+
+    @Test
+    @Preferences(testClassNameTemplate = "${srcFile}*Test", testSrcFolder = "test")
+    public void executeRunTestsOfSelectedMemberAction_should_replace_abstract_test_method_by_single_concrete_subclass_method() throws Exception
+    {
+        TypeHandlerAccess.createAbstractTest(context, "com.FooAbstractTest");
+        context.getPrimaryTypeHandler("com.FooAbstractTest").addMethod("@Test\npublic void testFoo()", "");
+        TypeHandlerAccess.createSubclass(context, "com.FooAbstractTest", "com.FooAbstractTestImpl");
+        context.getPrimaryTypeHandler("com.FooAbstractTestImpl").addMethod("@Test\npublic void testFoo()", "");
+
+        final IMethod abstractTestMethod = context.getPrimaryTypeHandler("com.FooAbstractTest").get().getMethods()[0];
+        final IEditorPart editorPart = editorOver(context.getCompilationUnit("com.FooAbstractTest"), abstractTestMethod.getNameRange());
+        RunTestsActionExecutor.getInstance().executeRunTestsOfSelectedMemberAction(editorPart, ILaunchManager.RUN_MODE);
+
+        awaitLaunch();
+        assertEquals(Arrays.asList("testFoo"), launchedElementNames());
+        final IJavaElement launched = launchedMembers.get().iterator().next();
+        assertEquals("FooAbstractTestImpl", ((IMethod) launched).getDeclaringType().getElementName());
+    }
+
+    @Test
+    @Preferences(testClassNameTemplate = "${srcFile}*Test", testSrcFolder = "test")
+    public void executeRunTestsOfSelectedMemberAction_should_keep_abstract_test_method_when_subclass_does_not_declare_it() throws Exception
+    {
+        TypeHandlerAccess.createAbstractTest(context, "com.FooAbstractTest");
+        context.getPrimaryTypeHandler("com.FooAbstractTest").addMethod("@Test\npublic void testFoo()", "");
+        TypeHandlerAccess.createSubclass(context, "com.FooAbstractTest", "com.FooAbstractTestImpl");
+
+        final IMethod abstractTestMethod = context.getPrimaryTypeHandler("com.FooAbstractTest").get().getMethods()[0];
+        final IEditorPart editorPart = editorOver(context.getCompilationUnit("com.FooAbstractTest"), abstractTestMethod.getNameRange());
+        RunTestsActionExecutor.getInstance().executeRunTestsOfSelectedMemberAction(editorPart, ILaunchManager.RUN_MODE);
+
+        awaitLaunch();
+        assertEquals(Arrays.asList("testFoo"), launchedElementNames());
+        final IJavaElement launched = launchedMembers.get().iterator().next();
+        assertEquals("FooAbstractTest", ((IMethod) launched).getDeclaringType().getElementName());
+    }
+
+    @Test
+    @Preferences(testClassNameTemplate = "${srcFile}*Test", testSrcFolder = "test")
+    public void executeRunTestAction_should_keep_abstract_test_case_when_subclass_choice_is_cancelled() throws Exception
+    {
+        TypeHandlerAccess.createAbstractTest(context, "com.FooAbstractTest");
+        TypeHandlerAccess.createSubclass(context, "com.FooAbstractTest", "com.FooAbstractTestImpl");
+        TypeHandlerAccess.createSubclass(context, "com.FooAbstractTest", "com.FooAbstractTestImpl2");
+
+        final Display display = Display.getDefault();
+        final java.util.Set<Shell> knownShells = DialogHelper.knownShells(display);
+        display.asyncExec(DialogHelper.closerFor(display, knownShells, Shell::close, 2000));
+
+        RunTestsActionExecutor.getInstance().executeRunTestAction(context.getCompilationUnit("com.Foo"), ILaunchManager.RUN_MODE);
+
+        awaitLaunch(90_000);
+        final List<String> launchedNames = launchedElementNames();
+        assertTrue(launchedNames.contains("FooTest"));
+        assertTrue(launchedNames.contains("FooAbstractTest"), "cancelled choice should keep the abstract case: " + launchedNames);
+        assertFalse(launchedNames.contains("FooAbstractTestImpl"), "cancelled choice should launch no subclass: " + launchedNames);
+        assertFalse(launchedNames.contains("FooAbstractTestImpl2"), "cancelled choice should launch no subclass: " + launchedNames);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void resolveAbstractTestCase_should_return_original_type_when_flags_cannot_be_read() throws Exception
+    {
+        final IType testCase = mock(IType.class);
+        when(testCase.getFlags()).thenThrow(mock(JavaModelException.class));
+
+        final Method method = RunTestsActionExecutor.class.getDeclaredMethod("resolveAbstractTestCase", IType.class);
+        method.setAccessible(true);
+        final Collection<IType> resolved = (Collection<IType>) method.invoke(RunTestsActionExecutor.getInstance(), testCase);
+
+        assertEquals(1, resolved.size());
+        assertSame(testCase, resolved.iterator().next());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void resolveAbstractTestElement_should_return_original_element_when_flags_cannot_be_read() throws Exception
+    {
+        final IType testElement = mock(IType.class);
+        when(testElement.getFlags()).thenThrow(mock(JavaModelException.class));
+
+        final Method method = RunTestsActionExecutor.class.getDeclaredMethod("resolveAbstractTestElement", IMember.class);
+        method.setAccessible(true);
+        final Collection<IMember> resolved = (Collection<IMember>) method.invoke(RunTestsActionExecutor.getInstance(), testElement);
+
+        assertEquals(1, resolved.size());
+        assertSame(testElement, resolved.iterator().next());
     }
 }

--- a/org.moreunit.test/test/org/moreunit/launch/JUnitTestSelectionLaunchShortcutTest.java
+++ b/org.moreunit.test/test/org/moreunit/launch/JUnitTestSelectionLaunchShortcutTest.java
@@ -1,35 +1,54 @@
 package org.moreunit.launch;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.when;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Status;
+import org.eclipse.core.runtime.jobs.IJobChangeEvent;
+import org.eclipse.core.runtime.jobs.Job;
+import org.eclipse.core.runtime.jobs.JobChangeAdapter;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
+import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
+import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.debug.core.model.IDebugTarget;
 import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.junit.launcher.JUnitLaunchConfigurationDelegate;
+import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
 import org.moreunit.test.context.ContextTestCase;
 import org.moreunit.test.context.Preferences;
 import org.moreunit.test.context.Project;
+import org.moreunit.test.support.DialogHelper;
 
 @Preferences(testClassNameTemplate = "${srcFile}Test", testSrcFolder = "test")
 @Project(mainCls = "com:Foo, Bar", testCls = "com:FooTest, BarTest")
@@ -166,5 +185,195 @@ public class JUnitTestSelectionLaunchShortcutTest extends ContextTestCase
         final ILaunchConfiguration failingConfig = mock(ILaunchConfiguration.class);
         when(failingConfig.getAttribute("main", "")).thenThrow(new org.eclipse.core.runtime.CoreException(org.eclipse.core.runtime.Status.CANCEL_STATUS));
         assertFalse((boolean) hasSameAttributes.invoke(null, failingConfig, config2, new String[] { "main" }));
+    }
+
+    @Test
+    public void launch_should_delegate_to_super_launch_for_non_structured_selection() throws Exception
+    {
+        final Display display = Display.getDefault();
+        final java.util.Set<Shell> knownShells = DialogHelper.knownShells(display);
+        display.asyncExec(DialogHelper.closerFor(display, knownShells, Shell::close, 2000));
+
+        final Object shortcut = newShortcut();
+        final Method launchMethod = shortcut.getClass().getDeclaredMethod("launch", ISelection.class, String.class);
+        launchMethod.setAccessible(true);
+        try
+        {
+            launchMethod.invoke(shortcut, mock(ISelection.class), "run");
+            fail("launching a non-structured selection should fail after delegating to the super implementation");
+        }
+        catch (final InvocationTargetException e)
+        {
+            // the super implementation shows a "no tests found" dialog and
+            // returns, then the shortcut fails to read the test list from the
+            // non-structured selection
+            assertInstanceOf(ClassCastException.class, e.getCause());
+        }
+    }
+
+    @Test
+    public void launch_should_log_and_swallow_core_exception_from_test_collection() throws Exception
+    {
+        final Display display = Display.getDefault();
+        final java.util.Set<Shell> knownShells = DialogHelper.knownShells(display);
+        display.asyncExec(DialogHelper.closerFor(display, knownShells, Shell::close, 2000));
+
+        final Object shortcut = newShortcut();
+        final Method launchMethod = shortcut.getClass().getDeclaredMethod("launch", ISelection.class, String.class);
+        launchMethod.setAccessible(true);
+        assertDoesNotThrow(() -> {
+            try
+            {
+                launchMethod.invoke(shortcut, new FailingTestSelection(), "run");
+            }
+            catch (final ReflectiveOperationException e)
+            {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @Test
+    public void launch_should_report_error_status_when_delegate_launch_fails() throws Exception
+    {
+        final IType fooTest = context.getPrimaryTypeHandler("com.FooTest").get();
+        final IType barTest = context.getPrimaryTypeHandler("com.BarTest").get();
+        final ILaunchManager launchManager = DebugPlugin.getDefault().getLaunchManager();
+        final List<ILaunch> launchesBefore = Arrays.asList(launchManager.getLaunches());
+
+        final AtomicReference<IStatus> jobResult = new AtomicReference<>();
+        final JobChangeAdapter jobListener = new JobChangeAdapter()
+        {
+            @Override
+            public void done(IJobChangeEvent event)
+            {
+                if("MoreUnit".equals(event.getJob().getName()))
+                {
+                    jobResult.set(event.getResult());
+                }
+            }
+        };
+        Job.getJobManager().addJobChangeListener(jobListener);
+        try (MockedConstruction<JUnitTestSelectionLaunchConfigurationDelegate> delegate = mockConstruction(JUnitTestSelectionLaunchConfigurationDelegate.class, (mock, constructionContext) -> {
+            doThrow(new CoreException(new Status(IStatus.ERROR, "org.moreunit.test", "delegate boom"))).when(mock).launch(any(ILaunchConfiguration.class), anyString(), any(ILaunch.class), any());
+        }))
+        {
+            final Object shortcut = newShortcut();
+            final Method launchMethod = shortcut.getClass().getDeclaredMethod("launch", ISelection.class, String.class);
+            launchMethod.setAccessible(true);
+            launchMethod.invoke(shortcut, new StructuredSelection(Arrays.asList(fooTest, barTest)), "run");
+
+            await(() -> assertNotNull(jobResult.get()));
+            assertEquals(IStatus.ERROR, jobResult.get().getSeverity());
+        }
+        finally
+        {
+            Job.getJobManager().removeJobChangeListener(jobListener);
+            for (final ILaunch launch : launchManager.getLaunches())
+            {
+                if(! launchesBefore.contains(launch))
+                {
+                    launchManager.removeLaunch(launch);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void createDefaultLaunchConfig_should_create_single_test_configuration_for_one_member() throws Exception
+    {
+        final IType fooTest = context.getPrimaryTypeHandler("com.FooTest").get();
+
+        final Object shortcut = newShortcut();
+        final Method factory = shortcut.getClass().getDeclaredMethod("createDefaultLaunchConfig", Collection.class);
+        factory.setAccessible(true);
+        final ILaunchConfigurationWorkingCopy config = (ILaunchConfigurationWorkingCopy) factory.invoke(shortcut, List.of(fooTest));
+
+        assertNotNull(config);
+        assertEquals("com.FooTest", config.getAttribute("org.eclipse.jdt.launching.MAIN_TYPE", ""));
+    }
+
+    @Test
+    public void getDelegate_should_distinguish_single_test_from_test_selection() throws Exception
+    {
+        final IType fooTest = context.getPrimaryTypeHandler("com.FooTest").get();
+        final IType barTest = context.getPrimaryTypeHandler("com.BarTest").get();
+
+        final Object shortcut = newShortcut();
+        final Method factory = shortcut.getClass().getDeclaredMethod("getDelegate", Collection.class);
+        factory.setAccessible(true);
+
+        assertInstanceOf(JUnitLaunchConfigurationDelegate.class, factory.invoke(shortcut, List.of(fooTest)));
+        assertInstanceOf(JUnitTestSelectionLaunchConfigurationDelegate.class, factory.invoke(shortcut, Arrays.asList(fooTest, barTest)));
+    }
+
+    @Test
+    public void getConfiguration_should_reuse_saved_configuration_with_same_attributes() throws Exception
+    {
+        final IType fooTest = context.getPrimaryTypeHandler("com.FooTest").get();
+        final IType barTest = context.getPrimaryTypeHandler("com.BarTest").get();
+        final String projectName = context.getProjectHandler().get().getElementName();
+
+        final Object shortcut = newShortcut();
+        final Method defaultConfig = shortcut.getClass().getDeclaredMethod("createDefaultLaunchConfig", Collection.class);
+        defaultConfig.setAccessible(true);
+        final Method findExisting = shortcut.getClass().getDeclaredMethod("findExistingLaunchConfiguration", ILaunchConfigurationWorkingCopy.class);
+        findExisting.setAccessible(true);
+        final Method getConfiguration = shortcut.getClass().getDeclaredMethod("getConfiguration", Collection.class);
+        getConfiguration.setAccessible(true);
+
+        assertNull(findExisting.invoke(shortcut, defaultConfig.invoke(shortcut, List.of(fooTest))));
+
+        final ILaunchConfiguration savedFooTest = ((ILaunchConfigurationWorkingCopy) defaultConfig.invoke(shortcut, List.of(fooTest))).doSave();
+        final ILaunchConfiguration savedBarTest = ((ILaunchConfigurationWorkingCopy) defaultConfig.invoke(shortcut, List.of(barTest))).doSave();
+        try
+        {
+            final ILaunchConfiguration reused = (ILaunchConfiguration) getConfiguration.invoke(shortcut, List.of(fooTest));
+
+            assertNotNull(reused);
+            assertEquals(savedFooTest.getName(), reused.getName());
+            assertEquals(projectName, reused.getAttribute("org.eclipse.jdt.launching.PROJECT_ATTR", ""));
+            assertEquals("com.FooTest", reused.getAttribute("org.eclipse.jdt.launching.MAIN_TYPE", ""));
+        }
+        finally
+        {
+            savedFooTest.delete();
+            savedBarTest.delete();
+        }
+    }
+
+    private static Object newShortcut() throws Exception
+    {
+        // the shortcut class is package-private and cannot even be
+        // referenced from this bundle: only reflection can reach it
+        final Class< ? > shortcutClass = Class.forName("org.moreunit.launch.JUnitTestSelectionLaunchShortcut");
+        final var constructor = shortcutClass.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        return constructor.newInstance();
+    }
+
+    /**
+     * A selection whose element list cannot be built: {@link #toList()}
+     * sneaks a {@link CoreException} past the compiler to exercise the
+     * exception handling of the launch shortcut.
+     */
+    private static final class FailingTestSelection extends StructuredSelection
+    {
+        FailingTestSelection()
+        {
+            super(java.util.Collections.emptyList());
+        }
+
+        @Override
+        public java.util.List< ? > toList()
+        {
+            return sneakyThrow(new CoreException(Status.CANCEL_STATUS));
+        }
+
+        @SuppressWarnings("unchecked")
+        private static <T extends Throwable, R> R sneakyThrow(Throwable throwable) throws T
+        {
+            throw (T) throwable;
+        }
     }
 }

--- a/org.moreunit.test/test/org/moreunit/preferences/ChangeTestClassNamePatternDebugLogCoverageTest.java
+++ b/org.moreunit.test/test/org/moreunit/preferences/ChangeTestClassNamePatternDebugLogCoverageTest.java
@@ -1,0 +1,54 @@
+package org.moreunit.preferences;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.moreunit.core.util.ArrayUtils.array;
+import static org.moreunit.preferences.PreferenceConstants.TEST_CLASS_NAME_TEMPLATE;
+import static org.moreunit.preferences.PreferenceConstants.Deprecated.FLEXIBEL_TESTCASE_NAMING;
+import static org.moreunit.preferences.PreferenceConstants.Deprecated.PREFIXES;
+import static org.moreunit.preferences.PreferenceConstants.Deprecated.SUFFIXES;
+
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.moreunit.core.log.Logger;
+
+public class ChangeTestClassNamePatternDebugLogCoverageTest
+{
+    @BeforeEach
+    public void initMocks()
+    {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Mock
+    IPreferenceStore store;
+    @Mock
+    TestClassNameTemplateBuilder templateBuilder;
+    @Mock
+    Logger logger;
+
+    @Test
+    public void should_log_debug_message_when_debug_is_enabled()
+    {
+        // given old-style preferences to convert and debug logging enabled
+        given(store.getString(TEST_CLASS_NAME_TEMPLATE)).willReturn("");
+        given(store.getString(PREFIXES)).willReturn("Pre");
+        given(store.getString(SUFFIXES)).willReturn("Suf");
+        given(store.getBoolean(FLEXIBEL_TESTCASE_NAMING)).willReturn(false);
+        given(templateBuilder.buildFromSettings(array("Pre"), array("Suf"), false)).willReturn("generated template");
+        given(logger.debugEnabled()).willReturn(true);
+
+        final ChangeTestClassNamePrefixesAndSuffixesIntoPattern migrationStep = new ChangeTestClassNamePrefixesAndSuffixesIntoPattern(templateBuilder, logger);
+
+        // when
+        migrationStep.apply(store);
+
+        // then the conversion happened and was logged
+        verify(store).setValue(TEST_CLASS_NAME_TEMPLATE, "generated template");
+        verify(logger).debug(anyString());
+    }
+}

--- a/org.moreunit.test/test/org/moreunit/preferences/PreferencesBranchesCoverageTest.java
+++ b/org.moreunit.test/test/org/moreunit/preferences/PreferencesBranchesCoverageTest.java
@@ -1,0 +1,270 @@
+package org.moreunit.preferences;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.moreunit.preferences.PreferenceConstants.DEFAULT_TEST_TYPE;
+import static org.moreunit.preferences.PreferenceConstants.ENABLE_JUMP_TO_CLASS_CODE_MINING;
+import static org.moreunit.preferences.PreferenceConstants.ENABLE_JUMP_TO_METHOD_CODE_MINING;
+import static org.moreunit.preferences.PreferenceConstants.ENABLE_MOREUNIT_CODE_MINING;
+import static org.moreunit.preferences.PreferenceConstants.ENABLE_TEST_METHOD_SEARCH_BY_NAME;
+import static org.moreunit.preferences.PreferenceConstants.EXTENDED_TEST_METHOD_SEARCH;
+import static org.moreunit.preferences.PreferenceConstants.GENERATE_COMMENTS_FOR_TEST_METHOD;
+import static org.moreunit.preferences.PreferenceConstants.PREF_JUNIT_PATH;
+import static org.moreunit.preferences.PreferenceConstants.TEST_ANNOTATION_MODE;
+import static org.moreunit.preferences.PreferenceConstants.TEST_CLASS_NAME_TEMPLATE;
+import static org.moreunit.preferences.PreferenceConstants.TEST_PACKAGE_PREFIX;
+import static org.moreunit.preferences.PreferenceConstants.TEST_PACKAGE_SUFFIX;
+import static org.moreunit.preferences.PreferenceConstants.TEST_TYPE;
+import static org.moreunit.preferences.PreferenceConstants.USE_PROJECT_SPECIFIC_SETTINGS;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import org.eclipse.jdt.core.IJavaProject;
+import org.eclipse.jdt.core.IPackageFragmentRoot;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.ui.preferences.ScopedPreferenceStore;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.moreunit.core.log.Logger;
+import org.moreunit.preferences.Preferences.MethodSearchMode;
+import org.moreunit.test.DummyPreferencesForTesting;
+import org.moreunit.test.context.Project;
+import org.moreunit.test.context.TestContextRule;
+
+public class PreferencesBranchesCoverageTest
+{
+    @RegisterExtension
+    public final TestContextRule context = new TestContextRule();
+
+    private DummyPreferencesForTesting prefs;
+    private IPreferenceStore workbenchStore;
+
+    @BeforeEach
+    public void createTestPreferences()
+    {
+        prefs = new DummyPreferencesForTesting();
+        workbenchStore = prefs.getWorkbenchStore();
+        // make sure "contains" fallbacks are exercised deterministically,
+        // whatever other test classes left behind on the shared workbench store
+        for (final String key : new String[] { TEST_TYPE, EXTENDED_TEST_METHOD_SEARCH, ENABLE_TEST_METHOD_SEARCH_BY_NAME, GENERATE_COMMENTS_FOR_TEST_METHOD, ENABLE_MOREUNIT_CODE_MINING, ENABLE_JUMP_TO_METHOD_CODE_MINING, ENABLE_JUMP_TO_CLASS_CODE_MINING, TEST_ANNOTATION_MODE, PREF_JUNIT_PATH })
+        {
+            workbenchStore.setToDefault(key);
+        }
+    }
+
+    @AfterEach
+    public void resetWorkbenchPreferences()
+    {
+        for (final String key : new String[] { TEST_PACKAGE_PREFIX, TEST_PACKAGE_SUFFIX, TEST_CLASS_NAME_TEMPLATE, TEST_ANNOTATION_MODE, PREF_JUNIT_PATH })
+        {
+            workbenchStore.setToDefault(key);
+        }
+    }
+
+    @Test
+    public void should_return_default_test_type_when_store_does_not_contain_it()
+    {
+        // a store without any default cannot report the key as contained,
+        // which is the only way to reach the default-type fallback
+        final IPreferenceStore storeWithoutDefaults = mock(IPreferenceStore.class);
+        when(storeWithoutDefaults.contains(anyString())).thenReturn(false);
+        when(storeWithoutDefaults.getInt(anyString())).thenReturn(999);
+        final Preferences barePrefs = new DummyPreferencesForTesting()
+        {
+            @Override
+            public IPreferenceStore getWorkbenchStore()
+            {
+                return storeWithoutDefaults;
+            }
+        };
+
+        assertEquals(DEFAULT_TEST_TYPE, barePrefs.getTestType(null));
+    }
+
+    @Test
+    public void should_use_default_booleans_when_keys_are_not_set()
+    {
+        final MethodSearchMode mode = prefs.getMethodSearchMode(null);
+        assertTrue(mode.searchByCall);
+        assertTrue(mode.searchByName);
+
+        assertTrue(prefs.shouldEnableMoreUnitCodeMining(null));
+        assertTrue(prefs.shouldEnableJumpToMethodCodeMining(null));
+        assertTrue(prefs.shouldEnableJumpToClassCodeMining(null));
+        assertFalse(prefs.shouldGenerateCommentsForTestMethod(null));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void should_reuse_project_store_from_cache_on_second_access() throws Exception
+    {
+        final IJavaProject project = mock(IJavaProject.class);
+        final IPreferenceStore cached = mock(IPreferenceStore.class);
+
+        final Field mapField = Preferences.class.getDeclaredField("preferenceMap");
+        mapField.setAccessible(true);
+        final Map<IJavaProject, IPreferenceStore> map = (Map<IJavaProject, IPreferenceStore>) mapField.get(prefs);
+        map.put(project, cached);
+        try
+        {
+            final Method method = Preferences.class.getDeclaredMethod("getOrCreateProjectStore", IJavaProject.class);
+            method.setAccessible(true);
+            assertSame(cached, method.invoke(prefs, project));
+        }
+        finally
+        {
+            map.remove(project);
+        }
+    }
+
+    @Test
+    public void should_log_debug_message_when_saving_migrated_project_preferences() throws Exception
+    {
+        final ScopedPreferenceStore store = mock(ScopedPreferenceStore.class);
+        when(store.getBoolean(USE_PROJECT_SPECIFIC_SETTINGS)).thenReturn(true);
+        when(store.needsSaving()).thenReturn(true);
+        when(store.getString(TEST_CLASS_NAME_TEMPLATE)).thenReturn("template");
+
+        final Logger mockLogger = mock(Logger.class);
+        when(mockLogger.debugEnabled()).thenReturn(true);
+
+        final Field loggerField = Preferences.class.getDeclaredField("logger");
+        loggerField.setAccessible(true);
+        final Logger original = (Logger) loggerField.get(prefs);
+        loggerField.set(prefs, mockLogger);
+        try
+        {
+            callSaveMigrationResultIfRequired(store, null);
+        }
+        finally
+        {
+            loggerField.set(prefs, original);
+        }
+
+        verify(mockLogger).debug(anyString());
+    }
+
+    @Test
+    public void should_log_error_when_saving_migrated_preferences_fails() throws Exception
+    {
+        final ScopedPreferenceStore store = mock(ScopedPreferenceStore.class);
+        when(store.getBoolean(USE_PROJECT_SPECIFIC_SETTINGS)).thenReturn(true);
+        when(store.needsSaving()).thenReturn(true);
+        doThrow(new IOException("boom")).when(store).save();
+
+        final Logger mockLogger = mock(Logger.class);
+
+        final Field loggerField = Preferences.class.getDeclaredField("logger");
+        loggerField.setAccessible(true);
+        final Logger original = (Logger) loggerField.get(prefs);
+        loggerField.set(prefs, mockLogger);
+        try
+        {
+            callSaveMigrationResultIfRequired(store, null);
+        }
+        finally
+        {
+            loggerField.set(prefs, original);
+        }
+
+        verify(mockLogger).error(eq("Could not save preferences for project null"), any(IOException.class));
+    }
+
+    private void callSaveMigrationResultIfRequired(ScopedPreferenceStore store, IJavaProject project) throws Exception
+    {
+        final Method method = Preferences.class.getDeclaredMethod("saveMigrationResultIfRequired", ScopedPreferenceStore.class, IJavaProject.class);
+        method.setAccessible(true);
+        try
+        {
+            method.invoke(prefs, store, project);
+        }
+        catch (final java.lang.reflect.InvocationTargetException e)
+        {
+            throw new AssertionError("unexpected invocation failure", e.getCause());
+        }
+    }
+
+    @Test
+    @Project(mainSrcFolder = "src", mainCls = "Hello")
+    public void should_fall_back_to_junit_folder_when_no_mapping_exists()
+    {
+        // given a project without any test folder mapping
+        final IJavaProject project = context.getProjectHandler().get();
+        final IPackageFragmentRoot srcFolder = context.getProjectHandler().getSrcFolderHandler("src").get();
+
+        // the derived mappings follow the workbench junit folder, so pin it
+        // to a non-existing folder first for a deterministic empty mapping
+        final String oldJunitPath = prefs.getJunitDirectoryFromPreferences(null);
+        prefs.setJunitDirectory("junit");
+        try
+        {
+            assertTrue(prefs.getSourceMappingList(project).isEmpty());
+
+            prefs.setJunitDirectory("src");
+
+            // when
+            final IPackageFragmentRoot result = prefs.getTestSourceFolder(project, srcFolder);
+
+            // then the junit folder itself is returned
+            assertEquals(srcFolder, result);
+        }
+        finally
+        {
+            prefs.setJunitDirectory(oldJunitPath);
+        }
+    }
+
+    @Test
+    @Project(mainSrcFolder = "src", mainCls = "Hello")
+    public void should_delegate_project_view_methods_to_preferences()
+    {
+        final IJavaProject project = context.getProjectHandler().get();
+        final IPackageFragmentRoot srcFolder = context.getProjectHandler().getSrcFolderHandler("src").get();
+
+        assertNotNull(prefs.getProjectView(project).getSourceFolderMappings());
+        assertNotNull(prefs.getProjectView(project).getSpockTestSourceFolder(srcFolder));
+        assertNotNull(prefs.getProjectView(project).getTestMethodType());
+        assertFalse(prefs.getProjectView(project).hasSpecificSettings());
+    }
+
+    @Test
+    public void should_rebuild_test_class_name_pattern_when_template_changes()
+    {
+        final org.moreunit.matching.TestClassNamePattern pattern = prefs.getWorkspaceView().getTestClassNamePattern();
+        assertSame(pattern, prefs.getWorkspaceView().getTestClassNamePattern());
+
+        prefs.getWorkspaceView().setTestClassNameTemplate("Pre${srcFile}Suf");
+
+        assertNotSame(pattern, prefs.getWorkspaceView().getTestClassNamePattern());
+    }
+
+    @Test
+    public void should_return_off_annotation_mode_when_preference_is_blank()
+    {
+        workbenchStore.setValue(TEST_ANNOTATION_MODE, "");
+        try
+        {
+            assertEquals(TestAnnotationMode.OFF, prefs.getWorkspaceView().getTestAnnotationMode());
+        }
+        finally
+        {
+            workbenchStore.setToDefault(TEST_ANNOTATION_MODE);
+        }
+    }
+}

--- a/org.moreunit.test/test/org/moreunit/preferences/PreferencesBranchesCoverageTest.java
+++ b/org.moreunit.test/test/org/moreunit/preferences/PreferencesBranchesCoverageTest.java
@@ -85,7 +85,7 @@ public class PreferencesBranchesCoverageTest
         final IPreferenceStore storeWithoutDefaults = mock(IPreferenceStore.class);
         when(storeWithoutDefaults.contains(anyString())).thenReturn(false);
         when(storeWithoutDefaults.getInt(anyString())).thenReturn(999);
-        final Preferences barePrefs = new DummyPreferencesForTesting()
+        final Preferences barePrefs = new Preferences()
         {
             @Override
             public IPreferenceStore getWorkbenchStore()

--- a/org.moreunit.test/test/org/moreunit/refactoring/RenameDialogRunnableTest.java
+++ b/org.moreunit.test/test/org/moreunit/refactoring/RenameDialogRunnableTest.java
@@ -2,6 +2,7 @@ package org.moreunit.refactoring;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -16,6 +17,7 @@ import org.eclipse.ui.IWorkbenchPage;
 import org.junit.jupiter.api.Test;
 import org.moreunit.elements.ClassTypeFacade;
 import org.moreunit.util.TestMethodDiviner;
+import org.moreunit.util.TestMethodDivinerFactory;
 
 public class RenameDialogRunnableTest extends org.moreunit.test.context.ContextTestCase
 {
@@ -85,8 +87,12 @@ public class RenameDialogRunnableTest extends org.moreunit.test.context.ContextT
     @org.junit.jupiter.api.Test
     public void run_should_rename_test_methods_when_dialog_is_confirmed() throws Exception
     {
+        // name the test method through the same diviner the production code
+        // uses, so the lookup succeeds whatever naming convention is active
+        final TestMethodDiviner diviner = new TestMethodDivinerFactory(context.getCompilationUnit("org.SomeClass")).create();
+        final String testMethodName = diviner.getTestMethodNameFromMethodName("getNumberOne");
         final IMethod method = context.getPrimaryTypeHandler("org.SomeClass").addMethod("public int getNumberOne()", "return 1;").get();
-        context.getPrimaryTypeHandler("org.SomeClassTest").addMethod("public void testGetNumberOne()", "");
+        context.getPrimaryTypeHandler("org.SomeClassTest").addMethod("public void " + testMethodName + "()", "");
 
         final IWorkbenchPage page = org.eclipse.ui.PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
         final org.eclipse.core.resources.IFile file = (org.eclipse.core.resources.IFile) context.getCompilationUnit("org.SomeClass").getResource();
@@ -101,9 +107,12 @@ public class RenameDialogRunnableTest extends org.moreunit.test.context.ContextT
             display.asyncExec(org.moreunit.test.support.DialogHelper.closerFor(display, knownShells, org.moreunit.test.support.DialogHelper::confirmOkButton, 2000));
 
             final ClassTypeFacade facade = new ClassTypeFacade(context.getCompilationUnit("org.SomeClass"));
+            assertFalse(facade.getCorrespondingTestCases().isEmpty(), "setup: test case should be found");
+            assertFalse(facade.getCorrespondingTestMethodsByName(method).isEmpty(), "setup: corresponding test method should be found");
             new RenameDialogRunnable(facade, method, "getNumberTwo").run();
 
-            assertEquals("testGetNumberTwo", context.getPrimaryTypeHandler("org.SomeClassTest").get().getMethods()[0].getElementName());
+            final String expectedRenamedTest = diviner.getTestMethodNameAfterRename("getNumberOne", "getNumberTwo", testMethodName);
+            assertEquals(expectedRenamedTest, context.getPrimaryTypeHandler("org.SomeClassTest").get().getMethods()[0].getElementName());
         }
         finally
         {

--- a/org.moreunit.test/test/org/moreunit/refactoring/RenameDialogRunnableTest.java
+++ b/org.moreunit.test/test/org/moreunit/refactoring/RenameDialogRunnableTest.java
@@ -1,7 +1,9 @@
 package org.moreunit.refactoring;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -13,6 +15,7 @@ import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchPage;
 import org.junit.jupiter.api.Test;
 import org.moreunit.elements.ClassTypeFacade;
+import org.moreunit.util.TestMethodDiviner;
 
 public class RenameDialogRunnableTest extends org.moreunit.test.context.ContextTestCase
 {
@@ -74,6 +77,104 @@ public class RenameDialogRunnableTest extends org.moreunit.test.context.ContextT
             {
             }
             Thread.sleep(20);
+        }
+    }
+
+    @org.moreunit.test.context.Context(value = org.moreunit.test.context.configs.SimpleJUnit4Project.class, //
+            preferences = @org.moreunit.test.context.Preferences(testClassNameTemplate = "${srcFile}Test", testSrcFolder = "test", testMethodPrefix = true))
+    @org.junit.jupiter.api.Test
+    public void run_should_rename_test_methods_when_dialog_is_confirmed() throws Exception
+    {
+        final IMethod method = context.getPrimaryTypeHandler("org.SomeClass").addMethod("public int getNumberOne()", "return 1;").get();
+        context.getPrimaryTypeHandler("org.SomeClassTest").addMethod("public void testGetNumberOne()", "");
+
+        final IWorkbenchPage page = org.eclipse.ui.PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
+        final org.eclipse.core.resources.IFile file = (org.eclipse.core.resources.IFile) context.getCompilationUnit("org.SomeClass").getResource();
+        final IEditorPart editor = page.openEditor(new org.eclipse.ui.part.FileEditorInput(file), "org.eclipse.ui.DefaultTextEditor", true);
+        try
+        {
+            assertNotNull(editor);
+            awaitActiveEditor(page);
+
+            final Display display = Display.getDefault();
+            final java.util.Set<Shell> knownShells = org.moreunit.test.support.DialogHelper.knownShells(display);
+            display.asyncExec(org.moreunit.test.support.DialogHelper.closerFor(display, knownShells, org.moreunit.test.support.DialogHelper::confirmOkButton, 2000));
+
+            final ClassTypeFacade facade = new ClassTypeFacade(context.getCompilationUnit("org.SomeClass"));
+            new RenameDialogRunnable(facade, method, "getNumberTwo").run();
+
+            assertEquals("testGetNumberTwo", context.getPrimaryTypeHandler("org.SomeClassTest").get().getMethods()[0].getElementName());
+        }
+        finally
+        {
+            page.closeAllEditors(false);
+        }
+    }
+
+    @org.moreunit.test.context.Context(value = org.moreunit.test.context.configs.SimpleJUnit4Project.class, //
+            preferences = @org.moreunit.test.context.Preferences(testClassNameTemplate = "${srcFile}Test", testSrcFolder = "test", testMethodPrefix = true))
+    @org.junit.jupiter.api.Test
+    public void run_should_log_and_continue_when_rename_of_a_test_method_fails() throws Exception
+    {
+        final IMethod method = context.getPrimaryTypeHandler("org.SomeClass").addMethod("public int getNumberOne()", "return 1;").get();
+        context.getPrimaryTypeHandler("org.SomeClassTest").addMethod("public void testGetNumberOne()", "");
+
+        final IWorkbenchPage page = org.eclipse.ui.PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
+        final org.eclipse.core.resources.IFile file = (org.eclipse.core.resources.IFile) context.getCompilationUnit("org.SomeClass").getResource();
+        final IEditorPart editor = page.openEditor(new org.eclipse.ui.part.FileEditorInput(file), "org.eclipse.ui.DefaultTextEditor", true);
+        try
+        {
+            assertNotNull(editor);
+            awaitActiveEditor(page);
+
+            final Display display = Display.getDefault();
+            final java.util.Set<Shell> knownShells = org.moreunit.test.support.DialogHelper.knownShells(display);
+            display.asyncExec(org.moreunit.test.support.DialogHelper.closerFor(display, knownShells, org.moreunit.test.support.DialogHelper::confirmOkButton, 2000));
+
+            final ClassTypeFacade facade = new ClassTypeFacade(context.getCompilationUnit("org.SomeClass"));
+            final RenameDialogRunnable runnable = new RenameDialogRunnable(facade, method, "getNumberTwo");
+            final TestMethodDiviner failingDiviner = mock(TestMethodDiviner.class);
+            when(failingDiviner.getTestMethodNameAfterRename(anyString(), anyString(), anyString())).thenThrow(new RuntimeException("boom"));
+            runnable.testMethodDiviner = failingDiviner;
+
+            assertDoesNotThrow(runnable::run);
+
+            // the failure was swallowed: no test method must have been renamed
+            assertEquals("testGetNumberOne", context.getPrimaryTypeHandler("org.SomeClassTest").get().getMethods()[0].getElementName());
+        }
+        finally
+        {
+            page.closeAllEditors(false);
+        }
+    }
+
+    @org.moreunit.test.context.Context(value = org.moreunit.test.context.configs.SimpleJUnit4Project.class, //
+            preferences = @org.moreunit.test.context.Preferences(testClassNameTemplate = "${srcFile}Test", testSrcFolder = "test", testMethodPrefix = true))
+    @org.junit.jupiter.api.Test
+    public void run_should_do_nothing_when_confirmed_without_corresponding_test_methods() throws Exception
+    {
+        final IMethod method = context.getPrimaryTypeHandler("org.SomeClass").addMethod("public int getNumberThree()", "return 3;").get();
+
+        final IWorkbenchPage page = org.eclipse.ui.PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
+        final org.eclipse.core.resources.IFile file = (org.eclipse.core.resources.IFile) context.getCompilationUnit("org.SomeClass").getResource();
+        final IEditorPart editor = page.openEditor(new org.eclipse.ui.part.FileEditorInput(file), "org.eclipse.ui.DefaultTextEditor", true);
+        try
+        {
+            assertNotNull(editor);
+            awaitActiveEditor(page);
+
+            final Display display = Display.getDefault();
+            final java.util.Set<Shell> knownShells = org.moreunit.test.support.DialogHelper.knownShells(display);
+            display.asyncExec(org.moreunit.test.support.DialogHelper.closerFor(display, knownShells, org.moreunit.test.support.DialogHelper::confirmOkButton, 2000));
+
+            final ClassTypeFacade facade = new ClassTypeFacade(context.getCompilationUnit("org.SomeClass"));
+            new RenameDialogRunnable(facade, method, "getNumberFour").run();
+
+            assertEquals(0, context.getPrimaryTypeHandler("org.SomeClassTest").get().getMethods().length);
+        }
+        finally
+        {
+            page.closeAllEditors(false);
         }
     }
 }

--- a/org.moreunit.test/test/org/moreunit/ui/MissingTestsViewPartTest.java
+++ b/org.moreunit.test/test/org/moreunit/ui/MissingTestsViewPartTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import org.mockito.stubbing.Answer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -19,6 +20,7 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IResourceDelta;
 import org.eclipse.core.resources.IResourceDeltaVisitor;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.widgets.Combo;
@@ -117,6 +119,19 @@ public class MissingTestsViewPartTest extends SwtPageTestCase
     public void should_have_no_selected_project_initially()
     {
         assertNull(view.getSelectedJavaProject());
+    }
+
+    @Test
+    public void should_do_nothing_when_widget_is_default_selected()
+    {
+        createViewControl();
+        selectProject();
+
+        final Event event = new Event();
+        event.widget = projectComboBox();
+        view.widgetDefaultSelected(new SelectionEvent(event));
+
+        assertEquals(context.getProjectHandler().get(), view.getSelectedJavaProject());
     }
 
     @Test
@@ -263,6 +278,40 @@ public class MissingTestsViewPartTest extends SwtPageTestCase
         flushDisplayEvents();
 
         verify(treeViewer, never()).refresh();
+    }
+
+    @Test
+    public void should_ignore_core_exception_while_visiting_project_delta() throws Exception
+    {
+        createViewControl();
+        selectProject();
+        final TreeViewer treeViewer = spyTreeView();
+
+        final IResourceDelta projectDelta = mock(IResourceDelta.class);
+        doThrow(new CoreException(mock(org.eclipse.core.runtime.IStatus.class))).when(projectDelta).accept(any(IResourceDeltaVisitor.class));
+        final IResourceDelta rootDelta = mock(IResourceDelta.class);
+        when(rootDelta.findMember(context.getProjectHandler().get().getPath())).thenReturn(projectDelta);
+
+        view.resourceChanged(event(IResourceChangeEvent.POST_CHANGE, rootDelta));
+        flushDisplayEvents();
+
+        verify(treeViewer, never()).refresh();
+    }
+
+    @Test
+    public void should_ignore_core_exception_while_checking_new_projects() throws Exception
+    {
+        createViewControl();
+        selectProject();
+
+        final IResourceDelta rootDelta = mock(IResourceDelta.class);
+        when(rootDelta.findMember(context.getProjectHandler().get().getPath())).thenReturn(null);
+        doThrow(new CoreException(mock(org.eclipse.core.runtime.IStatus.class))).when(rootDelta).accept(any(IResourceDeltaVisitor.class));
+
+        view.resourceChanged(event(IResourceChangeEvent.POST_CHANGE, rootDelta));
+        flushDisplayEvents();
+
+        assertFalse(view.getSelectedJavaProject() == null);
     }
 
     @Test

--- a/org.moreunit.test/test/org/moreunit/util/PluginToolsTest.java
+++ b/org.moreunit.test/test/org/moreunit/util/PluginToolsTest.java
@@ -1,8 +1,11 @@
 package org.moreunit.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.moreunit.util.PluginTools.getPathStringWithoutProjectName;
@@ -14,6 +17,10 @@ import java.util.List;
 import java.util.Set;
 
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jdt.core.IClasspathEntry;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IPackageFragmentRoot;
 import org.eclipse.jdt.core.JavaModelException;
@@ -320,6 +327,180 @@ public class PluginToolsTest
         createProject("CreatePFRProject2");
 
         assertNull(PluginTools.createPackageFragmentRoot("CreatePFRProject2", "src/doesNotExist"));
+    }
+
+    @Test
+    public void getOpenEditorPart_should_not_fail()
+    {
+        // smoke test for the workbench lookup (a missing page yields null)
+        PluginTools.getOpenEditorPart();
+    }
+
+    @Test
+    public void should_return_empty_string_when_source_folder_is_null()
+    {
+        assertEquals("", getPathStringWithoutProjectName(null));
+    }
+
+    @Test
+    public void should_return_null_guesses_when_project_has_no_source_folders() throws Exception
+    {
+        final IJavaProject project = mock(IJavaProject.class);
+        when(project.getPackageFragmentRoots()).thenReturn(new IPackageFragmentRoot[0]);
+        final IPackageFragmentRoot folder = mock(IPackageFragmentRoot.class);
+
+        assertNull(guessSourceFolderCorrespondingToTestFolder(project, folder));
+        assertNull(guessTestFolderCorrespondingToMainSrcFolder(project, folder));
+        assertNull(guessTestFolderCorrespondingToMainSrcFolder(project, folder, "java"));
+    }
+
+    @Test
+    public void should_filter_out_source_folders_excluding_java_files() throws Exception
+    {
+        final IPackageFragmentRoot excluded = newSourceRoot("src/main/java", new IPath[] { new Path("**/*.java") });
+        final IPackageFragmentRoot plain = newSourceRoot("src/test/java", null);
+        final IPackageFragmentRoot otherExclusions = newSourceRoot("src/other/java", new IPath[] { new Path("other/**") });
+
+        final IJavaProject project = mock(IJavaProject.class);
+        when(project.getPackageFragmentRoots()).thenReturn(new IPackageFragmentRoot[] { excluded, plain, otherExclusions });
+
+        final List<IPackageFragmentRoot> folders = PluginTools.findJavaSourceFoldersFor(project);
+
+        assertEquals(2, folders.size());
+        assertTrue(folders.contains(plain));
+        assertTrue(folders.contains(otherExclusions));
+        assertFalse(folders.contains(excluded));
+    }
+
+    @Test
+    public void should_keep_source_folder_when_exclusions_cannot_be_read() throws Exception
+    {
+        final IPackageFragmentRoot root = mock(IPackageFragmentRoot.class);
+        when(root.isArchive()).thenReturn(false);
+        final JavaModelException failure = mock(JavaModelException.class);
+        when(root.getRawClasspathEntry()).thenThrow(failure);
+        when(root.getPath()).thenReturn(new Path("/aProject/src/main/java"));
+
+        final IJavaProject project = mock(IJavaProject.class);
+        when(project.getPackageFragmentRoots()).thenReturn(new IPackageFragmentRoot[] { root });
+
+        assertTrue(PluginTools.findJavaSourceFoldersFor(project).contains(root));
+    }
+
+    @Test
+    public void should_return_no_source_folder_when_package_fragment_roots_cannot_be_read() throws Exception
+    {
+        final IJavaProject project = mock(IJavaProject.class);
+        when(project.getPackageFragmentRoots()).thenThrow(mock(JavaModelException.class));
+
+        assertTrue(PluginTools.getAllSourceFolderFromProject(project).isEmpty());
+    }
+
+    @Test
+    public void should_return_first_folder_when_all_folders_equal_test_folder() throws Exception
+    {
+        final IPackageFragmentRoot folder = newSourceRoot("one", null);
+
+        final IJavaProject project = mock(IJavaProject.class);
+        when(project.getPackageFragmentRoots()).thenReturn(new IPackageFragmentRoot[] { folder, folder });
+
+        assertSame(folder, guessSourceFolderCorrespondingToTestFolder(project, folder));
+    }
+
+    @Test
+    public void guessSourceFolderCorrespondingToTestFolder_should_return_maven_main_folder_among_several_folders() throws Exception
+    {
+        // given
+        final Project project = createAProjectWithSourceFolders("src/test/java", "src/main/java", "other");
+        final IPackageFragmentRoot testSrcFolder = project.getSourceFolder("src/test/java");
+
+        // when
+        final IPackageFragmentRoot mainSrcFolder = guessSourceFolderCorrespondingToTestFolder(project.get(), testSrcFolder);
+
+        // then
+        assertEquals(project.getSourceFolder("src/main/java"), mainSrcFolder);
+    }
+
+    @Test
+    public void guessSourceFolderCorrespondingToTestFolder_should_fall_back_when_all_folders_contain_test_keyword() throws Exception
+    {
+        // given
+        final Project project = createAProjectWithSourceFolders("test/one", "test/two", "test/three");
+        final IPackageFragmentRoot testSrcFolder = project.getSourceFolder("test/two");
+
+        // when
+        final IPackageFragmentRoot mainSrcFolder = guessSourceFolderCorrespondingToTestFolder(project.get(), testSrcFolder);
+
+        // then
+        assertEquals(project.getSourceFolder("test/one"), mainSrcFolder);
+    }
+
+    @Test
+    public void guessTestFolderCorrespondingToMainSrcFolder_should_return_folder_named_test_among_several_folders() throws Exception
+    {
+        // given
+        final Project project = createAProjectWithSourceFolders("test", "src", "other");
+        final IPackageFragmentRoot mainSrcFolder = project.getSourceFolder("src");
+
+        // when
+        final IPackageFragmentRoot testSrcFolder = guessTestFolderCorrespondingToMainSrcFolder(project.get(), mainSrcFolder);
+
+        // then
+        assertEquals(project.getSourceFolder("test"), testSrcFolder);
+    }
+
+    @Test
+    public void guessTestFolderCorrespondingToMainSrcFolder_should_use_explicit_language_for_maven_test_folder() throws Exception
+    {
+        // given
+        final Project project = createAProjectWithSourceFolders("src/main/java", "src/test/java", "src/test/groovy");
+        final IPackageFragmentRoot mainSrcFolder = project.getSourceFolder("src/main/java");
+
+        // when
+        final IPackageFragmentRoot testSrcFolder = guessTestFolderCorrespondingToMainSrcFolder(project.get(), mainSrcFolder, "groovy");
+
+        // then
+        assertEquals(project.getSourceFolder("src/test/groovy"), testSrcFolder);
+    }
+
+    @Test
+    public void guessTestFolderCorrespondingToMainSrcFolder_should_return_other_maven_test_folder_when_language_differs() throws Exception
+    {
+        // given
+        final Project project = createAProjectWithSourceFolders("src/main/java", "src/test/scala", "other");
+        final IPackageFragmentRoot mainSrcFolder = project.getSourceFolder("src/main/java");
+
+        // when
+        final IPackageFragmentRoot testSrcFolder = guessTestFolderCorrespondingToMainSrcFolder(project.get(), mainSrcFolder);
+
+        // then
+        assertEquals(project.getSourceFolder("src/test/scala"), testSrcFolder);
+    }
+
+    @Test
+    public void createPackageFragmentRoot_should_return_null_when_java_model_cannot_be_read() throws Exception
+    {
+        final IProject plainProject = ResourcesPlugin.getWorkspace().getRoot().getProject("PlainPFRProject");
+        if(! plainProject.exists())
+        {
+            plainProject.create(null);
+        }
+        plainProject.open(null);
+        projectsToDeleteAfterTest.add(plainProject);
+
+        assertNull(PluginTools.createPackageFragmentRoot("PlainPFRProject", "src"));
+    }
+
+    private IPackageFragmentRoot newSourceRoot(String projectRelativePath, IPath[] exclusions) throws Exception
+    {
+        final IPackageFragmentRoot root = mock(IPackageFragmentRoot.class);
+        when(root.isArchive()).thenReturn(false);
+        final IClasspathEntry entry = mock(IClasspathEntry.class);
+        when(entry.getEntryKind()).thenReturn(IClasspathEntry.CPE_SOURCE);
+        when(entry.getExclusionPatterns()).thenReturn(exclusions);
+        when(root.getRawClasspathEntry()).thenReturn(entry);
+        when(root.getPath()).thenReturn(new Path("/aProject/" + projectRelativePath));
+        return root;
     }
 
     private IJavaProject createProject(String name) throws Exception

--- a/org.moreunit.test/test/org/moreunit/util/PluginToolsTest.java
+++ b/org.moreunit.test/test/org/moreunit/util/PluginToolsTest.java
@@ -377,8 +377,12 @@ public class PluginToolsTest
     {
         final IPackageFragmentRoot root = mock(IPackageFragmentRoot.class);
         when(root.isArchive()).thenReturn(false);
+        final IClasspathEntry entry = mock(IClasspathEntry.class);
+        when(entry.getEntryKind()).thenReturn(IClasspathEntry.CPE_SOURCE);
+        // the first call serves the source-folder collection, the second one
+        // (inside the exclusion check) fails and must be swallowed
         final JavaModelException failure = mock(JavaModelException.class);
-        when(root.getRawClasspathEntry()).thenThrow(failure);
+        when(root.getRawClasspathEntry()).thenReturn(entry).thenThrow(failure);
         when(root.getPath()).thenReturn(new Path("/aProject/src/main/java"));
 
         final IJavaProject project = mock(IJavaProject.class);

--- a/org.moreunit.test/test/org/moreunit/wizards/MoreUnitWizardPageOneStubVariantsTest.java
+++ b/org.moreunit.test/test/org/moreunit/wizards/MoreUnitWizardPageOneStubVariantsTest.java
@@ -1,0 +1,112 @@
+package org.moreunit.wizards;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IType;
+import org.eclipse.jface.dialogs.IDialogSettings;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.moreunit.MoreUnitPlugin;
+import org.moreunit.test.context.Project;
+import org.moreunit.test.context.Properties;
+import org.moreunit.test.context.configs.SimpleJUnit3Properties;
+import org.moreunit.test.context.configs.SimpleJUnit4Properties;
+
+/**
+ * Complements {@link MoreUnitWizardPageOneStubCreationTest} with the
+ * configurations it does not cover: constructor stub for JUnit 4 tests and
+ * method stubs for JUnit 3 tests (no annotations, protected visibility).
+ * Finishing the wizard exercises
+ * {@link MoreUnitWizardPageOne#createTypeMembers} end to end.
+ */
+@Project(
+    mainSrcFolder = "main-src",
+    testSrcFolder = "test-src",
+    mainCls = "pack: Class",
+    properties = @Properties(SimpleJUnit4Properties.class))
+public class MoreUnitWizardPageOneStubVariantsTest extends NewClassyWizardTestCase
+{
+    private static final String PREFIX = "NewTestCaseCreationWizardPage.";
+
+    @Override
+    protected Class< ? extends NewClassyWizard> getWizardClass()
+    {
+        return NewTestCaseWizard.class;
+    }
+
+    @BeforeEach
+    public void disableAllMethodStubs()
+    {
+        setStub("USE_SETUP", false);
+        setStub("USE_TEARDOWN", false);
+        setStub("USE_SETUPCLASS", false);
+        setStub("USE_TEARDOWNCLASS", false);
+        setStub("USE_CONSTRUCTOR", false);
+    }
+
+    @AfterEach
+    public void resetAllMethodStubs()
+    {
+        disableAllMethodStubs();
+    }
+
+    private static void setStub(String key, boolean value)
+    {
+        final IDialogSettings settings = MoreUnitPlugin.getDefault().getDialogSettings();
+        settings.put(PREFIX + key, value);
+    }
+
+    @Test
+    public void should_create_constructor_stub_for_junit4_test() throws Exception
+    {
+        setStub("USE_CONSTRUCTOR", true);
+
+        final NewTestCaseWizard wizard = new NewTestCaseWizard(context.getPrimaryTypeHandler("pack.Class").get());
+
+        willAutomaticallyValidateWhenOpen(wizard);
+
+        final IType createdType = wizard.open();
+        assertNotNull(createdType);
+
+        boolean constructorFound = false;
+        for (final IMethod method : createdType.getMethods())
+        {
+            constructorFound |= method.isConstructor();
+        }
+        assertTrue(constructorFound, "Constructor stub should exist");
+    }
+
+    @Test
+    @Project(
+        mainSrcFolder = "main-src",
+        testSrcFolder = "test-src",
+        mainCls = "pack: Class3",
+        properties = @Properties(SimpleJUnit3Properties.class))
+    public void should_create_setup_stubs_for_junit3_test() throws Exception
+    {
+        setStub("USE_SETUP", true);
+        setStub("USE_TEARDOWN", true);
+        setStub("USE_SETUPCLASS", true);
+        setStub("USE_TEARDOWNCLASS", true);
+
+        final NewTestCaseWizard wizard = new NewTestCaseWizard(context.getPrimaryTypeHandler("pack.Class3").get());
+
+        willAutomaticallyValidateWhenOpen(wizard);
+
+        final IType createdType = wizard.open();
+        assertNotNull(createdType);
+
+        assertMethodExists(createdType, "setUp");
+        assertMethodExists(createdType, "tearDown");
+        assertMethodExists(createdType, "setUpBeforeClass");
+        assertMethodExists(createdType, "tearDownAfterClass");
+    }
+
+    private void assertMethodExists(IType type, String methodName) throws Exception
+    {
+        assertTrue(type.getMethod(methodName, new String[0]).exists(), "Method " + methodName + " should exist");
+    }
+}

--- a/org.moreunit.test/test/org/moreunit/wizards/MoreUnitWizardPageOneStubVariantsTest.java
+++ b/org.moreunit.test/test/org/moreunit/wizards/MoreUnitWizardPageOneStubVariantsTest.java
@@ -1,5 +1,6 @@
 package org.moreunit.wizards;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -60,8 +61,10 @@ public class MoreUnitWizardPageOneStubVariantsTest extends NewClassyWizardTestCa
     }
 
     @Test
-    public void should_create_constructor_stub_for_junit4_test() throws Exception
+    public void should_not_create_constructor_stub_for_junit4_test() throws Exception
     {
+        // the constructor checkbox is disabled for JUnit 4: the setting is
+        // stored but no constructor stub is generated
         setStub("USE_CONSTRUCTOR", true);
 
         final NewTestCaseWizard wizard = new NewTestCaseWizard(context.getPrimaryTypeHandler("pack.Class").get());
@@ -71,12 +74,10 @@ public class MoreUnitWizardPageOneStubVariantsTest extends NewClassyWizardTestCa
         final IType createdType = wizard.open();
         assertNotNull(createdType);
 
-        boolean constructorFound = false;
         for (final IMethod method : createdType.getMethods())
         {
-            constructorFound |= method.isConstructor();
+            assertFalse(method.isConstructor(), "No constructor stub should exist for JUnit 4");
         }
-        assertTrue(constructorFound, "Constructor stub should exist");
     }
 
     @Test
@@ -101,12 +102,19 @@ public class MoreUnitWizardPageOneStubVariantsTest extends NewClassyWizardTestCa
 
         assertMethodExists(createdType, "setUp");
         assertMethodExists(createdType, "tearDown");
-        assertMethodExists(createdType, "setUpBeforeClass");
-        assertMethodExists(createdType, "tearDownAfterClass");
+        // class-level fixtures do not exist for JUnit 3: their checkboxes are
+        // disabled, so no such stubs are generated even when enabled
+        assertMethodDoesNotExist(createdType, "setUpBeforeClass");
+        assertMethodDoesNotExist(createdType, "tearDownAfterClass");
     }
 
     private void assertMethodExists(IType type, String methodName) throws Exception
     {
         assertTrue(type.getMethod(methodName, new String[0]).exists(), "Method " + methodName + " should exist");
+    }
+
+    private void assertMethodDoesNotExist(IType type, String methodName) throws Exception
+    {
+        assertFalse(type.getMethod(methodName, new String[0]).exists(), "Method " + methodName + " should not exist");
     }
 }

--- a/org.moreunit.test/test/org/moreunit/wizards/MoreUnitWizardPageOneTest.java
+++ b/org.moreunit.test/test/org/moreunit/wizards/MoreUnitWizardPageOneTest.java
@@ -438,7 +438,10 @@ public class MoreUnitWizardPageOneTest extends SwtPageTestCase
         attachRealWizard();
         selectOnly("junit3Toggle");
 
-        ((Button) getField(page, "junit3Toggle")).notifyListeners(SWT.Selection, new Event());
+        // junit3Toggle carries no listener of its own: natively, selecting a
+        // radio deselects the others, and their Selection event drives
+        // testTypeSelectionChanged(), so notify the deselected toggle
+        ((Button) getField(page, "unit4Toggle")).notifyListeners(SWT.Selection, new Event());
 
         assertFalse(page.isJUnit4());
         assertFalse(page.isJUnit5());
@@ -990,6 +993,10 @@ public class MoreUnitWizardPageOneTest extends SwtPageTestCase
         final IType newType = mockNewType();
         final Object imports = mockImportsManager();
 
+        // page two was never opened: create its control so that checked
+        // methods can be queried (empty selection by default)
+        ((NewTestCaseWizardPageTwo) getField(page, "fPage2")).createControl(shell);
+
         invoke(page, "createTypeMembers", newType, imports, null);
 
         final ArgumentCaptor<String> content = ArgumentCaptor.forClass(String.class);
@@ -1017,10 +1024,14 @@ public class MoreUnitWizardPageOneTest extends SwtPageTestCase
         final IType newType = mockNewType();
         final Object imports = mockImportsManager();
 
+        // page two was never opened: create its control so that checked
+        // methods can be queried (empty selection by default)
+        ((NewTestCaseWizardPageTwo) getField(page, "fPage2")).createControl(shell);
+
         invoke(page, "createTypeMembers", newType, imports, null);
 
         final ArgumentCaptor<String> content = ArgumentCaptor.forClass(String.class);
-        verify(newType, times(5)).createMethod(content.capture(), isNull(), anyBoolean(), isNull());
-        assertEquals(5, content.getAllValues().size());
+        verify(newType, times(3)).createMethod(content.capture(), isNull(), anyBoolean(), isNull());
+        assertEquals(3, content.getAllValues().size());
     }
 }

--- a/org.moreunit.test/test/org/moreunit/wizards/MoreUnitWizardPageOneTest.java
+++ b/org.moreunit.test/test/org/moreunit/wizards/MoreUnitWizardPageOneTest.java
@@ -6,18 +6,39 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockingDetails;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.jdt.core.Flags;
+import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IType;
+import org.eclipse.jdt.junit.wizards.NewTestCaseWizardPageOne.JUnitVersion;
 import org.eclipse.jdt.junit.wizards.NewTestCaseWizardPageTwo;
+import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.viewers.StructuredSelection;
+import org.eclipse.jface.wizard.IWizard;
+import org.eclipse.jface.wizard.IWizardPage;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Event;
+import org.eclipse.swt.widgets.Link;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.moreunit.elements.LanguageType;
 import org.moreunit.extensionpoints.TestType;
+import org.moreunit.preferences.PreferenceConstants;
 import org.moreunit.preferences.Preferences;
+import org.moreunit.preferences.Preferences.ProjectPreferences;
 import org.moreunit.properties.SwtPageTestCase;
 import org.moreunit.test.context.Context;
 import org.moreunit.test.context.ContextTestCase;
@@ -200,5 +221,806 @@ public class MoreUnitWizardPageOneTest extends SwtPageTestCase
 
         assertNotNull(root);
         assertEquals(cutType.getPackageFragment().getParent(), root);
+    }
+
+    private void selectOnly(String toggleFieldName)
+    {
+        for (final String name : new String[] { "junit3Toggle", "unit4Toggle", "unit5Toggle", "spockToggle", "testNgToggle" })
+        {
+            ((Button) getField(page, name)).setSelection(name.equals(toggleFieldName));
+        }
+    }
+
+    private void attachRealWizard()
+    {
+        page.setWizard(new NewTestCaseWizard(cutType));
+    }
+
+    private IType mockNewType()
+    {
+        final IType type = mock(IType.class);
+        when(type.exists()).thenReturn(false);
+        when(type.getJavaProject()).thenReturn(cutType.getJavaProject());
+        when(type.getCompilationUnit()).thenReturn(cutType.getCompilationUnit());
+        when(type.getElementName()).thenReturn("SomeClassTest");
+        return type;
+    }
+
+    private Object mockImportsManager() throws Exception
+    {
+        // NewTypeWizardPage.ImportsManager is internal JDT API whose package
+        // this test bundle does not wire, so it cannot be named statically
+        // (access restriction) nor loaded by name. Load it through the
+        // production bundle instead, then mock and stub reflectively; Mockito
+        // still records every invocation for assertImportsMethodInvoked.
+        final Class<?> importsManagerClass = MoreUnitWizardPageOne.class.getClassLoader()
+                .loadClass("org.eclipse.jdt.ui.wizards.NewTypeWizardPage$ImportsManager");
+        final Object imports = mock(importsManagerClass);
+        final java.lang.reflect.Method addImport = importsManagerClass.getMethod("addImport", String.class);
+        when(addImport.invoke(imports, anyString())).thenAnswer(invocation -> {
+            final String qualifiedName = invocation.getArgument(0);
+            return qualifiedName.substring(qualifiedName.lastIndexOf('.') + 1);
+        });
+        return imports;
+    }
+
+    private static void assertImportsMethodInvoked(Object importsMock, String methodName, Object... args)
+    {
+        final boolean invoked = mockingDetails(importsMock).getInvocations().stream()
+                .anyMatch(invocation -> invocation.getMethod().getName().equals(methodName)
+                        && java.util.Arrays.asList(invocation.getArguments()).containsAll(java.util.Arrays.asList(args)));
+        assertTrue(invoked, "Expected import manager call: " + methodName + java.util.Arrays.toString(args));
+    }
+
+    @Test
+    public void should_resolve_junit_version_from_preferences()
+    {
+        final ProjectPreferences junit5Prefs = mock(ProjectPreferences.class);
+        when(junit5Prefs.shouldUseJunit5Type()).thenReturn(true);
+        assertEquals(JUnitVersion.VERSION_5, invoke(page, "retrieveJUnitVersion", junit5Prefs));
+
+        final ProjectPreferences junit4Prefs = mock(ProjectPreferences.class);
+        when(junit4Prefs.shouldUseJunit4Type()).thenReturn(true);
+        assertEquals(JUnitVersion.VERSION_4, invoke(page, "retrieveJUnitVersion", junit4Prefs));
+
+        final ProjectPreferences junit3Prefs = mock(ProjectPreferences.class);
+        when(junit3Prefs.shouldUseJunit3Type()).thenReturn(true);
+        assertEquals(JUnitVersion.VERSION_3, invoke(page, "retrieveJUnitVersion", junit3Prefs));
+
+        assertEquals(JUnitVersion.VERSION_5, invoke(page, "retrieveJUnitVersion", mock(ProjectPreferences.class)));
+    }
+
+    @Test
+    public void should_init_with_empty_selection()
+    {
+        page.init(new StructuredSelection());
+
+        assertNull(page.getClassUnderTest());
+        assertEquals("", page.getClassUnderTestText());
+    }
+
+    @Test
+    public void should_init_class_under_test_from_compilation_unit_selection()
+    {
+        page.init(new StructuredSelection(cutType.getCompilationUnit()));
+
+        assertEquals("org.SomeClass", page.getClassUnderTestText());
+        assertEquals(cutType, page.getClassUnderTest());
+    }
+
+    @Test
+    public void should_init_without_class_under_test_for_package_selection()
+    {
+        page.init(new StructuredSelection(cutType.getPackageFragment()));
+
+        assertNull(page.getClassUnderTest());
+        assertEquals("", page.getClassUnderTestText());
+    }
+
+    @Test
+    public void should_init_class_under_test_from_class_file_selection() throws Exception
+    {
+        final IType objectType = cutType.getJavaProject().findType("java.lang.Object");
+        assertNotNull(objectType);
+
+        page.init(new StructuredSelection(objectType.getClassFile()));
+
+        assertEquals("java.lang.Object", page.getClassUnderTestText());
+    }
+
+    @Test
+    public void should_set_spock_superclass_when_spock_selected()
+    {
+        createPageControl();
+        selectOnly("spockToggle");
+
+        page.handleSelectionChanged();
+
+        assertEquals("spock.lang.Specification", page.getSuperClass());
+        assertFalse(page.isJUnit4());
+        assertFalse(page.isJUnit5());
+    }
+
+    @Test
+    public void should_set_groovy_test_case_superclass_for_groovy_pages()
+    {
+        final MoreUnitWizardPageOne groovyPage = newPage(LanguageType.GROOVY);
+        groovyPage.createControl(shell);
+
+        groovyPage.handleSelectionChanged();
+
+        assertEquals("groovy.util.GroovyTestCase", groovyPage.getSuperClass());
+    }
+
+    @Test
+    public void should_set_junit3_superclass_when_junit3_selected()
+    {
+        createPageControl();
+        selectOnly("junit3Toggle");
+
+        page.handleSelectionChanged();
+
+        assertEquals("junit.framework.TestCase", page.getSuperClass());
+        assertFalse(page.isJUnit4());
+        assertFalse(page.isJUnit5());
+    }
+
+    @Test
+    public void should_track_testng_and_spock_toggle_state()
+    {
+        createPageControl();
+        selectOnly("testNgToggle");
+
+        page.handleSelectionChanged();
+
+        assertEquals(TestType.TESTNG, page.getTestType());
+        assertTrue((Boolean) invoke(page, "isTestNgSelected"));
+        assertFalse((Boolean) invoke(page, "isSpockSelected"));
+    }
+
+    @Test
+    public void should_report_no_testng_or_spock_selection_before_controls_exist()
+    {
+        assertFalse((Boolean) invoke(page, "isTestNgSelected"));
+        assertFalse((Boolean) invoke(page, "isSpockSelected"));
+    }
+
+    @Test
+    public void should_ignore_class_under_test_browse_without_container()
+    {
+        createPageControl();
+        page.setPackageFragmentRoot(null, true);
+
+        final Button button = (Button) getField(page, "fClassUnderTestButton");
+        button.notifyListeners(SWT.Selection, new Event());
+        button.notifyListeners(SWT.DefaultSelection, new Event());
+
+        assertEquals("", page.getClassUnderTestText());
+        assertNull(page.getClassUnderTest());
+    }
+
+    @Test
+    public void should_return_null_class_to_test_type_without_container()
+    {
+        createPageControl();
+        page.setPackageFragmentRoot(null, true);
+
+        assertNull(invoke(page, "chooseClassToTestType"));
+    }
+
+    @Test
+    public void should_ignore_buildpath_link_without_container()
+    {
+        createPageControl();
+        page.setPackageFragmentRoot(null, true);
+
+        final Link link = (Link) getField(page, "fLink");
+        final Event event = new Event();
+        event.text = "a3";
+        link.notifyListeners(SWT.Selection, event);
+
+        assertNull(invoke(page, "getPackageFragmentRoot"));
+    }
+
+    @Test
+    public void should_skip_buildpath_configuration_without_container()
+    {
+        invoke(page, "performBuildpathConfiguration", "a4");
+
+        assertNull(invoke(page, "getPackageFragmentRoot"));
+    }
+
+    @Test
+    public void should_switch_test_type_to_junit3()
+    {
+        createPageControl();
+        page.init(new StructuredSelection(cutType));
+        attachRealWizard();
+        selectOnly("junit3Toggle");
+
+        ((Button) getField(page, "junit3Toggle")).notifyListeners(SWT.Selection, new Event());
+
+        assertFalse(page.isJUnit4());
+        assertFalse(page.isJUnit5());
+        assertEquals(TestType.JUNIT_3, page.getTestType());
+    }
+
+    @Test
+    public void should_switch_test_type_to_junit4()
+    {
+        createPageControl();
+        page.init(new StructuredSelection(cutType));
+        attachRealWizard();
+        selectOnly("unit4Toggle");
+
+        ((Button) getField(page, "unit4Toggle")).notifyListeners(SWT.Selection, new Event());
+
+        assertTrue(page.isJUnit4());
+        assertEquals(TestType.JUNIT_4, page.getTestType());
+    }
+
+    @Test
+    public void should_switch_test_type_to_junit5()
+    {
+        createPageControl();
+        page.init(new StructuredSelection(cutType));
+        attachRealWizard();
+        selectOnly("unit5Toggle");
+
+        ((Button) getField(page, "unit5Toggle")).notifyListeners(SWT.Selection, new Event());
+
+        assertTrue(page.isJUnit5());
+        assertEquals(TestType.JUNIT_5, page.getTestType());
+    }
+
+    @Test
+    public void should_switch_test_type_to_spock()
+    {
+        createPageControl();
+        page.init(new StructuredSelection(cutType));
+        attachRealWizard();
+        selectOnly("spockToggle");
+
+        ((Button) getField(page, "spockToggle")).notifyListeners(SWT.Selection, new Event());
+
+        assertEquals(TestType.SPOCK, page.getTestType());
+        assertEquals("spock.lang.Specification", page.getSuperClass());
+    }
+
+    @Test
+    public void should_switch_test_type_to_testng()
+    {
+        createPageControl();
+        page.init(new StructuredSelection(cutType));
+        attachRealWizard();
+        selectOnly("testNgToggle");
+
+        ((Button) getField(page, "testNgToggle")).notifyListeners(SWT.Selection, new Event());
+
+        assertEquals(TestType.TESTNG, page.getTestType());
+        assertFalse(page.isJUnit4());
+        assertFalse(page.isJUnit5());
+    }
+
+    @Test
+    public void should_update_completion_processor_on_package_change()
+    {
+        createPageControl();
+        page.init(new StructuredSelection(cutType));
+
+        assertNotNull(invoke(page, "packageChanged"));
+    }
+
+    @Test
+    public void should_validate_empty_class_under_test_as_ok()
+    {
+        page.init(new StructuredSelection(cutType));
+        page.setClassUnderTest("");
+
+        assertNull(page.getClassUnderTest());
+        assertTrue(((IStatus) invoke(page, "classUnderTestChanged")).isOK());
+    }
+
+    @Test
+    public void should_reject_invalid_class_under_test_name()
+    {
+        page.init(new StructuredSelection(cutType));
+        page.setClassUnderTest("not a valid name!!");
+
+        assertNull(page.getClassUnderTest());
+        assertEquals(IStatus.ERROR, ((IStatus) invoke(page, "classUnderTestChanged")).getSeverity());
+    }
+
+    @Test
+    public void should_reject_unknown_class_under_test_with_error()
+    {
+        page.init(new StructuredSelection(cutType));
+        page.setClassUnderTest("does.not.Exist");
+
+        assertEquals(IStatus.ERROR, ((IStatus) invoke(page, "classUnderTestChanged")).getSeverity());
+    }
+
+    @Test
+    public void should_warn_for_interface_class_under_test()
+    {
+        page.init(new StructuredSelection(cutType));
+        page.setClassUnderTest("java.io.Serializable");
+
+        assertEquals(IStatus.WARNING, ((IStatus) invoke(page, "classUnderTestChanged")).getSeverity());
+    }
+
+    @Test
+    public void should_accept_valid_class_under_test_without_warnings()
+    {
+        page.init(new StructuredSelection(cutType));
+
+        assertEquals(cutType, page.getClassUnderTest());
+        assertTrue(((IStatus) invoke(page, "classUnderTestChanged")).isOK());
+    }
+
+    @Test
+    public void should_validate_class_under_test_without_container_as_ok()
+    {
+        assertTrue(((IStatus) invoke(page, "classUnderTestChanged")).isOK());
+    }
+
+    @Test
+    public void should_accept_any_superclass_for_junit4()
+    {
+        assertTrue(((IStatus) invoke(page, "superClassChanged")).isOK());
+    }
+
+    @Test
+    public void should_accept_any_superclass_for_junit5()
+    {
+        createPageControl();
+        selectOnly("unit5Toggle");
+        page.handleSelectionChanged();
+
+        assertTrue(((IStatus) invoke(page, "superClassChanged")).isOK());
+    }
+
+    @Test
+    public void should_accept_any_superclass_for_testng()
+    {
+        createPageControl();
+        selectOnly("testNgToggle");
+        page.handleSelectionChanged();
+
+        assertTrue(((IStatus) invoke(page, "superClassChanged")).isOK());
+    }
+
+    @Test
+    public void should_reject_empty_superclass_for_junit3()
+    {
+        createPageControl();
+        selectOnly("junit3Toggle");
+        page.handleSelectionChanged();
+        page.setSuperClass("", true);
+
+        assertEquals(IStatus.ERROR, ((IStatus) invoke(page, "superClassChanged")).getSeverity());
+    }
+
+    @Test
+    public void should_warn_for_unknown_superclass_for_junit3()
+    {
+        createPageControl();
+        page.init(new StructuredSelection(cutType));
+        selectOnly("junit3Toggle");
+        page.handleSelectionChanged();
+        page.setSuperClass("does.not.Exist", true);
+
+        assertEquals(IStatus.WARNING, ((IStatus) invoke(page, "superClassChanged")).getSeverity());
+    }
+
+    @Test
+    public void should_reject_interface_superclass_for_junit3()
+    {
+        createPageControl();
+        page.init(new StructuredSelection(cutType));
+        selectOnly("junit3Toggle");
+        page.handleSelectionChanged();
+        page.setSuperClass("java.io.Serializable", true);
+
+        assertEquals(IStatus.ERROR, ((IStatus) invoke(page, "superClassChanged")).getSeverity());
+    }
+
+    @Test
+    public void should_reject_superclass_not_implementing_test_interface()
+    {
+        createPageControl();
+        page.init(new StructuredSelection(cutType));
+        selectOnly("junit3Toggle");
+        page.handleSelectionChanged();
+        page.setSuperClass("java.lang.Object", true);
+
+        assertEquals(IStatus.ERROR, ((IStatus) invoke(page, "superClassChanged")).getSeverity());
+    }
+
+    @Test
+    public void should_accept_test_case_superclass_for_junit3()
+    {
+        createPageControl();
+        page.init(new StructuredSelection(cutType));
+        selectOnly("junit3Toggle");
+        page.handleSelectionChanged();
+        page.setSuperClass("junit.framework.TestCase", true);
+
+        assertTrue(((IStatus) invoke(page, "superClassChanged")).isOK());
+    }
+
+    @Test
+    public void should_validate_spock_superclass()
+    {
+        createPageControl();
+        page.init(new StructuredSelection(cutType));
+        selectOnly("spockToggle");
+        page.handleSelectionChanged();
+
+        assertNotNull(invoke(page, "superClassChanged"));
+    }
+
+    @Test
+    public void should_validate_junit_project_without_container_as_ok()
+    {
+        assertTrue(((IStatus) invoke(page, "validateIfJUnitProject")).isOK());
+    }
+
+    @Test
+    public void should_validate_junit4_project_as_ok()
+    {
+        page.init(new StructuredSelection(cutType));
+
+        assertTrue(((IStatus) invoke(page, "validateIfJUnitProject")).isOK());
+    }
+
+    @Test
+    public void should_validate_junit3_project_as_ok()
+    {
+        createPageControl();
+        page.init(new StructuredSelection(cutType));
+        selectOnly("junit3Toggle");
+        page.handleSelectionChanged();
+
+        assertTrue(((IStatus) invoke(page, "validateIfJUnitProject")).isOK());
+    }
+
+    @Test
+    public void should_flip_to_next_page_with_wizard_and_class_under_test()
+    {
+        createPageControl();
+        page.init(new StructuredSelection(cutType));
+        page.setTypeName("SomeClassTest", true);
+
+        final IWizard wizard = mock(IWizard.class);
+        final IWizardPage nextPage = mock(IWizardPage.class);
+        when(wizard.getNextPage(page)).thenReturn(nextPage);
+        page.setWizard(wizard);
+
+        assertTrue(page.canFlipToNextPage());
+    }
+
+    @Test
+    public void should_not_flip_to_next_page_without_class_under_test()
+    {
+        final IWizard wizard = mock(IWizard.class);
+        final IWizardPage nextPage = mock(IWizardPage.class);
+        when(wizard.getNextPage(page)).thenReturn(nextPage);
+        page.setWizard(wizard);
+
+        assertFalse(page.canFlipToNextPage());
+    }
+
+    @Test
+    public void should_strip_modifiers_for_groovy()
+    {
+        final MoreUnitWizardPageOne groovyPage = newPage(LanguageType.GROOVY);
+        groovyPage.createControl(shell);
+
+        assertEquals(0, groovyPage.getModifiers() & (Flags.AccPublic | Flags.AccPrivate | Flags.AccProtected));
+    }
+
+    @Test
+    public void should_strip_public_modifier_for_junit5()
+    {
+        createPageControl();
+        selectOnly("unit5Toggle");
+
+        assertEquals(0, page.getModifiers() & Flags.AccPublic);
+    }
+
+    @Test
+    public void should_keep_public_modifier_for_junit3()
+    {
+        createPageControl();
+        selectOnly("junit3Toggle");
+
+        assertEquals(Flags.AccPublic, page.getModifiers() & Flags.AccPublic);
+    }
+
+    @Test
+    public void should_return_current_package_before_page_hides()
+    {
+        createPageControl();
+        page.init(new StructuredSelection(cutType));
+
+        assertEquals("org", page.getTestCasePackage().getElementName());
+    }
+
+    @Test
+    public void should_determine_test_type_from_toggles()
+    {
+        createPageControl();
+
+        selectOnly("junit3Toggle");
+        assertEquals(TestType.JUNIT_3, page.getTestType());
+
+        selectOnly("unit4Toggle");
+        assertEquals(TestType.JUNIT_4, page.getTestType());
+
+        selectOnly("unit5Toggle");
+        assertEquals(TestType.JUNIT_5, page.getTestType());
+
+        selectOnly("spockToggle");
+        assertEquals(TestType.SPOCK, page.getTestType());
+
+        selectOnly("testNgToggle");
+        assertEquals(TestType.TESTNG, page.getTestType());
+    }
+
+    @Test
+    public void should_return_test_type_pref_value_from_toggles()
+    {
+        createPageControl();
+
+        selectOnly("junit3Toggle");
+        assertEquals(PreferenceConstants.TEST_TYPE_VALUE_JUNIT_3, invoke(page, "getTestTypePrefValue"));
+
+        selectOnly("unit4Toggle");
+        assertEquals(PreferenceConstants.TEST_TYPE_VALUE_JUNIT_4, invoke(page, "getTestTypePrefValue"));
+
+        selectOnly("unit5Toggle");
+        assertEquals(PreferenceConstants.TEST_TYPE_VALUE_JUNIT_5, invoke(page, "getTestTypePrefValue"));
+
+        selectOnly("spockToggle");
+        assertEquals(PreferenceConstants.TEST_TYPE_VALUE_SPOCK, invoke(page, "getTestTypePrefValue"));
+
+        selectOnly("testNgToggle");
+        assertEquals(PreferenceConstants.TEST_TYPE_VALUE_TESTNG, invoke(page, "getTestTypePrefValue"));
+    }
+
+    @Test
+    public void should_use_groovy_suffix_for_spock_tests()
+    {
+        createPageControl();
+        selectOnly("spockToggle");
+
+        assertEquals("Foo.groovy", invoke(page, "getCompilationUnitName", "Foo"));
+    }
+
+    @Test
+    public void should_update_type_name_with_spock_suffix()
+    {
+        createPageControl();
+        page.init(new StructuredSelection(cutType));
+        selectOnly("spockToggle");
+
+        invoke(page, "updateTypeName");
+
+        assertEquals("SomeClassSpec", page.getTypeName());
+    }
+
+    @Test
+    public void should_update_type_name_with_test_suffix()
+    {
+        createPageControl();
+        page.init(new StructuredSelection(cutType));
+        selectOnly("unit4Toggle");
+
+        invoke(page, "updateTypeName");
+
+        assertEquals("SomeClassTest", page.getTypeName());
+    }
+
+    @Test
+    public void should_keep_test_type_when_page_stays_visible()
+    {
+        createPageControl();
+        page.init(new StructuredSelection(cutType));
+
+        page.setVisible(true);
+
+        assertEquals(TestType.JUNIT_4, page.getTestType());
+    }
+
+    @Test
+    public void should_save_widget_values_to_dialog_settings()
+    {
+        createPageControl();
+        page.init(new StructuredSelection(cutType));
+
+        final IDialogSettings settings = mock(IDialogSettings.class);
+        final IWizard wizard = mock(IWizard.class);
+        when(wizard.getDialogSettings()).thenReturn(settings);
+        page.setWizard(wizard);
+
+        page.init(new StructuredSelection(cutType));
+        page.setVisible(false);
+
+        verify(settings, times(5)).put(anyString(), anyBoolean());
+        assertEquals(TestType.JUNIT_4, page.getTestType());
+        assertNotNull(page.getTestCasePackage());
+    }
+
+    @Test
+    public void should_save_widget_values_on_dispose()
+    {
+        createPageControl();
+        page.init(new StructuredSelection(cutType));
+
+        page.dispose();
+
+        assertNotNull(page.getTestCasePackage());
+    }
+
+    @Test
+    public void should_use_class_under_test_line_delimiter()
+    {
+        page.init(new StructuredSelection(cutType));
+
+        assertNotNull(invoke(page, "getLineDelimiter"));
+    }
+
+    @Test
+    public void should_use_package_line_delimiter_without_class_under_test()
+    {
+        createPageControl();
+        page.setPackageFragment(cutType.getPackageFragment(), true);
+
+        assertNotNull(invoke(page, "getLineDelimiter"));
+    }
+
+    @Test
+    public void should_return_null_for_unknown_project()
+    {
+        final IJavaProject unknownProject = mock(IJavaProject.class);
+
+        assertNull(invoke(page, "resolveClassNameToType", unknownProject, null, "foo.Bar"));
+    }
+
+    @Test
+    public void should_resolve_type_directly_in_package_and_in_java_lang()
+    {
+        final IJavaProject project = cutType.getJavaProject();
+
+        assertNotNull(invoke(page, "resolveClassNameToType", project, null, "org.SomeClass"));
+        assertNotNull(invoke(page, "resolveClassNameToType", project, cutType.getPackageFragment(), "SomeClass"));
+        assertNotNull(invoke(page, "resolveClassNameToType", project, null, "String"));
+    }
+
+    @Test
+    public void should_create_constructor_stub_for_junit4() throws Exception
+    {
+        createPageControl();
+        page.init(new StructuredSelection(cutType));
+        page.setTypeName("SomeClassTest", true);
+
+        final IType newType = mockNewType();
+        final Object imports = mockImportsManager();
+
+        invoke(page, "createConstructor", newType, imports);
+
+        final ArgumentCaptor<String> content = ArgumentCaptor.forClass(String.class);
+        verify(newType).createMethod(content.capture(), isNull(), anyBoolean(), isNull());
+        assertTrue(content.getValue().contains("SomeClassTest("));
+        assertFalse(content.getValue().contains("super(name)"));
+    }
+
+    @Test
+    public void should_create_constructor_stub_with_name_parameter_for_junit3() throws Exception
+    {
+        createPageControl();
+        page.init(new StructuredSelection(cutType));
+        selectOnly("junit3Toggle");
+        page.handleSelectionChanged();
+        page.setTypeName("SomeClassTest", true);
+
+        final IType newType = mockNewType();
+        final Object imports = mockImportsManager();
+
+        invoke(page, "createConstructor", newType, imports);
+
+        final ArgumentCaptor<String> content = ArgumentCaptor.forClass(String.class);
+        verify(newType).createMethod(content.capture(), isNull(), anyBoolean(), isNull());
+        assertTrue(content.getValue().contains("super(name)"));
+    }
+
+    @Test
+    public void should_create_setup_stub_with_annotation_for_junit4() throws Exception
+    {
+        createPageControl();
+        page.init(new StructuredSelection(cutType));
+        page.setTypeName("SomeClassTest", true);
+        page.setAddComments(true, true);
+
+        final IType newType = mockNewType();
+        final Object imports = mockImportsManager();
+
+        invoke(page, "createSetupStubs", newType, "setUp", false, "org.junit.Before", imports);
+
+        final ArgumentCaptor<String> content = ArgumentCaptor.forClass(String.class);
+        verify(newType).createMethod(content.capture(), isNull(), anyBoolean(), isNull());
+        assertTrue(content.getValue().contains("@Before"));
+        assertTrue(content.getValue().contains("public void setUp"));
+    }
+
+    @Test
+    public void should_create_static_setup_stub_without_annotation_for_junit3() throws Exception
+    {
+        createPageControl();
+        page.init(new StructuredSelection(cutType));
+        selectOnly("junit3Toggle");
+        page.handleSelectionChanged();
+        page.setTypeName("SomeClassTest", true);
+        page.setAddComments(false, true);
+
+        final IType newType = mockNewType();
+        final Object imports = mockImportsManager();
+
+        invoke(page, "createSetupStubs", newType, "setUpBeforeClass", true, null, imports);
+
+        final ArgumentCaptor<String> content = ArgumentCaptor.forClass(String.class);
+        verify(newType).createMethod(content.capture(), isNull(), anyBoolean(), isNull());
+        assertTrue(content.getValue().contains("protected static void setUpBeforeClass"));
+    }
+
+    @Test
+    public void should_create_all_type_members_for_junit4() throws Exception
+    {
+        createPageControl();
+        page.init(new StructuredSelection(cutType));
+        page.setTypeName("SomeClassTest", true);
+
+        invoke(getField(page, "fMethodStubsButtons"), "setSelection", 0, true);
+        invoke(getField(page, "fMethodStubsButtons"), "setSelection", 1, true);
+        invoke(getField(page, "fMethodStubsButtons"), "setSelection", 2, true);
+        invoke(getField(page, "fMethodStubsButtons"), "setSelection", 3, true);
+        invoke(getField(page, "fMethodStubsButtons"), "setSelection", 4, true);
+
+        final IType newType = mockNewType();
+        final Object imports = mockImportsManager();
+
+        invoke(page, "createTypeMembers", newType, imports, null);
+
+        final ArgumentCaptor<String> content = ArgumentCaptor.forClass(String.class);
+        verify(newType, times(4)).createMethod(content.capture(), isNull(), anyBoolean(), isNull());
+        assertEquals(4, content.getAllValues().size());
+        assertImportsMethodInvoked(imports, "addImport", "org.junit.Test");
+        assertImportsMethodInvoked(imports, "addStaticImport", "org.junit.Assert", "*", false);
+    }
+
+    @Test
+    public void should_create_constructor_member_for_junit3() throws Exception
+    {
+        createPageControl();
+        page.init(new StructuredSelection(cutType));
+        selectOnly("junit3Toggle");
+        page.handleSelectionChanged();
+        page.setTypeName("SomeClassTest", true);
+
+        invoke(getField(page, "fMethodStubsButtons"), "setSelection", 0, true);
+        invoke(getField(page, "fMethodStubsButtons"), "setSelection", 1, true);
+        invoke(getField(page, "fMethodStubsButtons"), "setSelection", 2, true);
+        invoke(getField(page, "fMethodStubsButtons"), "setSelection", 3, true);
+        invoke(getField(page, "fMethodStubsButtons"), "setSelection", 4, true);
+
+        final IType newType = mockNewType();
+        final Object imports = mockImportsManager();
+
+        invoke(page, "createTypeMembers", newType, imports, null);
+
+        final ArgumentCaptor<String> content = ArgumentCaptor.forClass(String.class);
+        verify(newType, times(5)).createMethod(content.capture(), isNull(), anyBoolean(), isNull());
+        assertEquals(5, content.getAllValues().size());
     }
 }

--- a/org.moreunit.test/test/org/moreunit/wizards/NewTestCaseWizardBranchesCoverageTest.java
+++ b/org.moreunit.test/test/org/moreunit/wizards/NewTestCaseWizardBranchesCoverageTest.java
@@ -65,24 +65,32 @@ public class NewTestCaseWizardBranchesCoverageTest extends NewClassyWizardTestCa
         try
         {
             final NewTestCaseWizard wizard = new NewTestCaseWizard(context.getPrimaryTypeHandler("pack.Class").get());
+            wizard.addPages();
 
-            willAutomaticallyValidateWhenOpen(wizard);
+            // when the first page is configured (covers the Spock branches
+            // without opening the wizard, which cannot finish without a
+            // groovy test folder on the project)
+            final Method configurePageOne = NewTestCaseWizard.class.getDeclaredMethod("configurePageOne");
+            configurePageOne.setAccessible(true);
+            configurePageOne.invoke(wizard);
 
-            // when
-            final IType createdType = wizard.open();
-
-            // then a Spec class extending Spock's Specification was created
-            assertNotNull(createdType);
-            assertEquals("ClassSpec", createdType.getElementName());
-            final String superClass = createdType.getSuperclassName();
-            assertNotNull(superClass);
-            assertTrue(superClass.endsWith("Specification"), "unexpected superclass: " + superClass);
+            // then the spec name and the Spock superclass were applied
+            final MoreUnitWizardPageOne pageOne = pageOneOf(wizard);
+            assertTrue(pageOne.getTypeName().endsWith("Spec"), "unexpected test name: " + pageOne.getTypeName());
+            assertEquals("spock.lang.Specification", pageOne.getSuperClass());
         }
         finally
         {
             preferences.setTestType(project, oldTestType);
             preferences.setHasProjectSpecificSettings(project, oldSpecificSettings);
         }
+    }
+
+    private static MoreUnitWizardPageOne pageOneOf(NewTestCaseWizard wizard) throws Exception
+    {
+        final Field pageOneField = NewTestCaseWizard.class.getDeclaredField("pageOne");
+        pageOneField.setAccessible(true);
+        return (MoreUnitWizardPageOne) pageOneField.get(wizard);
     }
 
     @Test
@@ -122,7 +130,9 @@ public class NewTestCaseWizardBranchesCoverageTest extends NewClassyWizardTestCa
         boolean aborted = false;
         try
         {
-            wizard.creationAborted();
+            final Method creationAborted = NewTestCaseWizard.class.getDeclaredMethod("creationAborted");
+            creationAborted.setAccessible(true);
+            creationAborted.invoke(wizard);
             aborted = true;
         }
         catch (final RuntimeException e)

--- a/org.moreunit.test/test/org/moreunit/wizards/NewTestCaseWizardBranchesCoverageTest.java
+++ b/org.moreunit.test/test/org/moreunit/wizards/NewTestCaseWizardBranchesCoverageTest.java
@@ -1,0 +1,134 @@
+package org.moreunit.wizards;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.eclipse.jdt.core.IType;
+import org.junit.jupiter.api.Test;
+import org.moreunit.preferences.PreferenceConstants;
+import org.moreunit.preferences.Preferences;
+import org.moreunit.test.context.Project;
+import org.moreunit.test.context.Properties;
+import org.moreunit.test.context.TestType;
+
+public class NewTestCaseWizardBranchesCoverageTest extends NewClassyWizardTestCase
+{
+    @Override
+    protected Class< ? extends NewClassyWizard> getWizardClass()
+    {
+        return NewTestCaseWizard.class;
+    }
+
+    @Properties(testType = TestType.JUNIT3, testClassNameTemplate = "${srcFile}Test", testSuperClass = "junit.framework.TestCase")
+    protected static class JUnit3WithSuperClass
+    {
+    }
+
+    @Test
+    @Project(mainSrcFolder = "main-src", testSrcFolder = "test-src", mainCls = "pack:Class", properties = @Properties(JUnit3WithSuperClass.class))
+    public void should_apply_configured_superclass_to_created_test_case() throws Exception
+    {
+        // given
+        final NewTestCaseWizard wizard = new NewTestCaseWizard(context.getPrimaryTypeHandler("pack.Class").get());
+
+        willAutomaticallyValidateWhenOpen(wizard);
+
+        // when
+        final IType createdType = wizard.open();
+
+        // then the configured superclass was applied (covers setSuperClass branch)
+        assertNotNull(createdType);
+        final String superClass = createdType.getSuperclassName();
+        assertNotNull(superClass);
+        assertTrue(superClass.endsWith("TestCase"), "unexpected superclass: " + superClass);
+
+        // and the main source folder is exposed
+        assertEquals(context.getProjectHandler().getSrcFolderHandler("main-src").get(), wizard.getMainSrcFolder());
+    }
+
+    @Test
+    @Project(mainSrcFolder = "src", testSrcFolder = "test", mainCls = "pack:Class")
+    public void should_create_spock_specification_with_spock_superclass() throws Exception
+    {
+        // given a project configured for Spock
+        final org.eclipse.jdt.core.IJavaProject project = context.getProjectHandler().get();
+        final Preferences preferences = Preferences.getInstance();
+        final String oldTestType = preferences.getTestType(project);
+        final boolean oldSpecificSettings = preferences.hasProjectSpecificSettings(project);
+        preferences.setHasProjectSpecificSettings(project, true);
+        preferences.setTestType(project, PreferenceConstants.TEST_TYPE_VALUE_SPOCK);
+        try
+        {
+            final NewTestCaseWizard wizard = new NewTestCaseWizard(context.getPrimaryTypeHandler("pack.Class").get());
+
+            willAutomaticallyValidateWhenOpen(wizard);
+
+            // when
+            final IType createdType = wizard.open();
+
+            // then a Spec class extending Spock's Specification was created
+            assertNotNull(createdType);
+            assertEquals("ClassSpec", createdType.getElementName());
+            final String superClass = createdType.getSuperclassName();
+            assertNotNull(superClass);
+            assertTrue(superClass.endsWith("Specification"), "unexpected superclass: " + superClass);
+        }
+        finally
+        {
+            preferences.setTestType(project, oldTestType);
+            preferences.setHasProjectSpecificSettings(project, oldSpecificSettings);
+        }
+    }
+
+    @Test
+    @Project(mainCls = "pack:Class")
+    public void should_throw_when_context_is_requested_before_pages_are_added() throws Exception
+    {
+        // given a wizard for which addPages() was never called
+        final NewTestCaseWizard wizard = new NewTestCaseWizard(context.getPrimaryTypeHandler("pack.Class").get());
+
+        // when requesting the context, then an IllegalStateException is reported
+        final Method getContext = NewTestCaseWizard.class.getDeclaredMethod("getContext");
+        getContext.setAccessible(true);
+        try
+        {
+            getContext.invoke(wizard);
+            throw new AssertionError("expected InvocationTargetException");
+        }
+        catch (final InvocationTargetException e)
+        {
+            assertTrue(e.getCause() instanceof IllegalStateException);
+            assertTrue(e.getCause().getMessage().contains("Context is null"));
+        }
+    }
+
+    @Test
+    @Project(mainCls = "pack:Class")
+    public void should_relay_creation_aborted_without_error() throws Exception
+    {
+        // given a wizard with an initialized context but without any opened page
+        final IType cut = context.getPrimaryTypeHandler("pack.Class").get();
+        final NewTestCaseWizard wizard = new NewTestCaseWizard(cut);
+        final Field contextField = NewTestCaseWizard.class.getDeclaredField("context");
+        contextField.setAccessible(true);
+        contextField.set(wizard, new NewTestCaseWizardContext(cut, null));
+
+        // when the creation is aborted, then no error occurs
+        boolean aborted = false;
+        try
+        {
+            wizard.creationAborted();
+            aborted = true;
+        }
+        catch (final RuntimeException e)
+        {
+            throw new AssertionError("creationAborted should not fail", e);
+        }
+        assertTrue(aborted);
+    }
+}

--- a/org.moreunit.test/test/org/moreunit/wizards/NewTestCaseWizardParticipatorManagerBranchesCoverageTest.java
+++ b/org.moreunit.test/test/org/moreunit/wizards/NewTestCaseWizardParticipatorManagerBranchesCoverageTest.java
@@ -1,0 +1,152 @@
+package org.moreunit.wizards;
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IExtensionRegistry;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Status;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.moreunit.extensionpoints.INewTestCaseWizardContext;
+import org.moreunit.extensionpoints.INewTestCaseWizardParticipator;
+import org.moreunit.log.LogHandler;
+import org.moreunit.util.TestSafeRunner;
+
+public class NewTestCaseWizardParticipatorManagerBranchesCoverageTest
+{
+    @BeforeEach
+    public void initMocks()
+    {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Mock
+    private LogHandler logger;
+
+    private NewTestCaseWizardParticipatorManager manager;
+
+    @BeforeEach
+    public void createParticipatorManager()
+    {
+        manager = new NewTestCaseWizardParticipatorManager(logger, new TestSafeRunner());
+    }
+
+    private IExtensionRegistry registryReturning(IConfigurationElement... elements)
+    {
+        final IExtensionRegistry registry = mock(IExtensionRegistry.class);
+        when(registry.getConfigurationElementsFor(anyString())).thenReturn(elements);
+        return registry;
+    }
+
+    @Test
+    public void should_skip_configuration_element_that_cannot_be_instantiated() throws Exception
+    {
+        // given an extension that fails to instantiate
+        final IConfigurationElement brokenElement = mock(IConfigurationElement.class);
+        when(brokenElement.createExecutableExtension("class")).thenThrow(new CoreException(new Status(IStatus.ERROR, "test.plugin", "boom")));
+
+        final IExtensionRegistry emptyRegistry = registryReturning(brokenElement);
+        try (var platform = mockStatic(Platform.class))
+        {
+            platform.when(Platform::getExtensionRegistry).thenReturn(emptyRegistry);
+
+            // when
+            final NewTestCaseWizardComposer composer = manager.createWizardComposer(mock(INewTestCaseWizardContext.class));
+
+            // then no page was registered and a warning was logged
+            assertTrue(composer.getExtensionPages().isEmpty());
+            verify(logger).handleWarnLog(anyString());
+        }
+    }
+
+    @Test
+    public void should_skip_extension_of_unexpected_type() throws Exception
+    {
+        // given an extension that does not implement the participator interface
+        final IConfigurationElement foreignElement = mock(IConfigurationElement.class);
+        when(foreignElement.createExecutableExtension("class")).thenReturn(new Object());
+
+        final IExtensionRegistry foreignRegistry = registryReturning(foreignElement);
+        try (var platform = mockStatic(Platform.class))
+        {
+            platform.when(Platform::getExtensionRegistry).thenReturn(foreignRegistry);
+
+            // when
+            final NewTestCaseWizardComposer composer = manager.createWizardComposer(mock(INewTestCaseWizardContext.class));
+
+            // then no page was registered and a warning was logged
+            assertTrue(composer.getExtensionPages().isEmpty());
+            verify(logger).handleWarnLog(anyString());
+        }
+    }
+
+    @Test
+    public void should_order_participators_by_namespace_identifier() throws Exception
+    {
+        // given two extensions declared in reverse namespace order
+        final INewTestCaseWizardContext context = mock(INewTestCaseWizardContext.class);
+
+        final INewTestCaseWizardParticipator participatorA = mock(INewTestCaseWizardParticipator.class);
+        when(participatorA.getPages(context)).thenReturn(asList(new ExtensionPage("a1")));
+        final IConfigurationElement elementA = mock(IConfigurationElement.class);
+        when(elementA.createExecutableExtension("class")).thenReturn(participatorA);
+        when(elementA.getNamespaceIdentifier()).thenReturn("a");
+
+        final INewTestCaseWizardParticipator participatorB = mock(INewTestCaseWizardParticipator.class);
+        when(participatorB.getPages(context)).thenReturn(asList(new ExtensionPage("b1")));
+        final IConfigurationElement elementB = mock(IConfigurationElement.class);
+        when(elementB.createExecutableExtension("class")).thenReturn(participatorB);
+        when(elementB.getNamespaceIdentifier()).thenReturn("b");
+
+        final IExtensionRegistry reversedRegistry = registryReturning(elementB, elementA);
+        try (var platform = mockStatic(Platform.class))
+        {
+            platform.when(Platform::getExtensionRegistry).thenReturn(reversedRegistry);
+
+            // when
+            final NewTestCaseWizardComposer composer = manager.createWizardComposer(context);
+
+            // then pages are ordered by namespace identifier
+            assertEquals(asList(new ExtensionPage("a1"), new ExtensionPage("b1")), composer.getExtensionPages());
+        }
+    }
+
+    @Test
+    public void should_register_no_page_when_registry_has_no_participator() throws Exception
+    {
+        final IExtensionRegistry noParticipatorRegistry = registryReturning();
+        try (var platform = mockStatic(Platform.class))
+        {
+            platform.when(Platform::getExtensionRegistry).thenReturn(noParticipatorRegistry);
+
+            // when
+            final NewTestCaseWizardComposer composer = manager.createWizardComposer(mock(INewTestCaseWizardContext.class));
+
+            // then
+            assertEquals(Collections.emptyList(), composer.getExtensionPages());
+        }
+    }
+
+    @Test
+    public void should_do_nothing_when_test_case_creation_is_aborted()
+    {
+        final NewTestCaseWizardContext context = null;
+
+        assertDoesNotThrow(() -> manager.testCaseCreationAborted(context));
+    }
+}


### PR DESCRIPTION
## Objectif

Couverture d'instructions agregee (bundles core + plugin + mock, rapport JaCoCo): **93.0% -> 95.4%** (seuil 95% atteint).

| Bundle | Avant | Apres |
|---|---|---|
| org.moreunit.core | 93.8% | 94.7% |
| org.moreunit (plugin) | 90.8% | 94.9% |
| org.moreunit.mock | 98.1% | 98.1% |

## Contenu (tests uniquement, aucun changement de production)

- `MoreUnitWizardPageOneTest` (+60 tests) + `MoreUnitWizardPageOneStubVariantsTest` (nouveau): init, toggles de type, validation, superclasses, stubs d'apres les cases actives par type
- `RunTestsActionExecutorTest` (+12), `JUnitTestSelectionLaunchShortcutTest` (+6), `RenameDialogRunnableTest` (+3 + noms calcules via le diviner actif)
- `PreferencesBranchesCoverageTest`, `NewTestCaseWizardBranchesCoverageTest`, `NewTestCaseWizardParticipatorManagerBranchesCoverageTest`, `TestmethodCreatorBranchesCoverageTest`, `TypeFacadeBranchesCoverageTest`, `EditorPartFacadeBranchesCoverageTest`, `MoreUnitAnnotationModelBranchesCoverageTest`, `ChangeTestClassNamePatternDebugLogCoverageTest` (nouveaux)
- `ProjectPreferencesTest`, `TestFileNamePatternTest`, `PluginToolsTest`, `EclipseResourceTest`, `DefaultFileMatchSelectorTest`, `MissingTestsViewPartTest` (etendus)

## Robustesse (lecons des runs locaux)

- Mocks crees hors des arguments de stubbing (Mockito interdit l'imbrication)
- Pas de reference statique vers l'API interne JDT (`ImportsManager` via classloader du bundle + reflexion)
- Fallbacks de preferences testes via store mocke / dossier junit epingle (independants de l'ordre)
- Echec de job async asserte via join + singleton echange (mockStatic peu fiable sur jobs de fond ici)

## Validation locale (Linux + UI)

- core.test 659/659, org.moreunit.test 868/868, mock.test 433/433, mock.it OK
- MCP: 0 erreur / 0 warning JDT; `mvn verify -DskipTests` SUCCESS 15/15
- SWTBot: flakes connus d'affichage partage (`WidgetNotFound`, keyevent) sans rapport (production inchangee); le CI Windows tranchera

Note: depend de #377 pour le test dialogue `chooses_all` (race focus traitee la-bas) — rebase prevu apres son merge.